### PR TITLE
feat: load subject prompts and materials

### DIFF
--- a/src/lib/services/resource.js
+++ b/src/lib/services/resource.js
@@ -1,0 +1,13 @@
+import { get } from 'svelte/store';
+import { subjectConfig, materialsLoaded } from '$lib/stores/subject-config';
+
+export async function getMaterialContent(filename) {
+  const config = get(subjectConfig);
+  if (!config) throw new Error('No subject selected');
+  const cache = get(materialsLoaded);
+  if (cache[filename]) return cache[filename];
+  const res = await fetch(`/tutor/${config.id}/materials/${filename}`);
+  const text = await res.text();
+  materialsLoaded.update((m) => ({ ...m, [filename]: text }));
+  return text;
+}

--- a/src/lib/stores/prompt.js
+++ b/src/lib/stores/prompt.js
@@ -11,6 +11,9 @@ export const SUBJECT_PROMPTS = {
     'You are a History tutor. Provide timeline, key causes/effects, and one primary-source style question.'
 };
 
+import { get } from 'svelte/store';
+import { subjectConfig } from './subject-config';
+
 export const FUN_PROMPTS = {
   anecdotes: 'You tell short, witty, family-friendly anecdotes. Keep it under 80 words.',
   motivation: 'You are a concise motivational coach. Be empathetic, 2-3 sentences max.',
@@ -23,8 +26,14 @@ export const FUN_PROMPTS = {
 };
 
 export function buildSystemPrompt({ mode, subject, activity }) {
-  if (mode === 'learning' && subject && SUBJECT_PROMPTS[subject]) {
-    return SUBJECT_PROMPTS[subject];
+  if (mode === 'learning' && subject) {
+    const cfg = get(subjectConfig);
+    if (cfg && cfg.id === subject && cfg.prompt) {
+      return cfg.prompt;
+    }
+    if (SUBJECT_PROMPTS[subject]) {
+      return SUBJECT_PROMPTS[subject];
+    }
   }
   if (mode === 'fun' && activity && FUN_PROMPTS[activity]) {
     return FUN_PROMPTS[activity];

--- a/src/lib/stores/subject-config.js
+++ b/src/lib/stores/subject-config.js
@@ -1,0 +1,28 @@
+import { writable, get } from 'svelte/store';
+
+export const subjectConfig = writable(null);
+export const materialsLoaded = writable({});
+
+export async function loadSubjectConfig(subjectId) {
+  const res = await fetch('/tutor/subjects.json');
+  const subjects = await res.json();
+  const info = subjects.find((s) => s.id === subjectId);
+  if (!info) throw new Error('Subject not found');
+  const [prompt, metadata] = await Promise.all([
+    fetch(info.promptPath).then((r) => r.text()),
+    info.metadataPath ? fetch(info.metadataPath).then((r) => r.json()) : Promise.resolve({})
+  ]);
+  subjectConfig.set({ id: subjectId, prompt, ...metadata });
+  materialsLoaded.set({});
+}
+
+export async function loadMaterial(filename) {
+  const config = get(subjectConfig);
+  if (!config) throw new Error('Subject not loaded');
+  const cache = get(materialsLoaded);
+  if (cache[filename]) return cache[filename];
+  const res = await fetch(`/tutor/${config.id}/materials/${filename}`);
+  const text = await res.text();
+  materialsLoaded.update((m) => ({ ...m, [filename]: text }));
+  return text;
+}

--- a/src/lib/stores/ui.js
+++ b/src/lib/stores/ui.js
@@ -1,6 +1,7 @@
 import { writable, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import { addSystemMessage } from '$lib/modules/chat/stores';
+import { loadSubjectConfig } from './subject-config';
 import { selectedLanguage } from '$lib/modules/i18n/stores';
 import { getTranslation } from '$lib/modules/i18n/translations';
 
@@ -42,6 +43,7 @@ export function setChatType(value) {
 export function setSubject(value) {
   subject.set(value);
   if (value) {
+    loadSubjectConfig(value).catch((e) => console.error('Failed to load subject config', e));
     const lang = get(selectedLanguage);
     const subj = getTranslation(lang, `subjects.${value}`);
     const msg = getTranslation(lang, 'banner.switched.subject').replace('{subject}', subj);

--- a/static/tutor/dele-b1/behavior-prompt.md
+++ b/static/tutor/dele-b1/behavior-prompt.md
@@ -1,0 +1,50 @@
+Act as DELE B1 Tutor Agent.
+CRITICAL INSTRUCTION: NO questions, no ideas, no proposals. Just now start acting.
+
+═══════════════════════════════════════════════════════════════
+
+# CORE TEACHING IDENTITY & BEHAVIORAL PROTOCOLS
+
+## AI Tutor Personality Framework
+
+**Teaching Philosophy**: Expert DELE B1 specialist with warm, encouraging, and precision-focused approach. Always maintain professional but supportive tone while strictly adhering to official exam standards.
+
+**Language Protocol**:
+
+- Interface instructions in selected language (English/Spanish/Russian)
+- ALL DELE tasks remain in Spanish only (non-negotiable)
+- Explanations adapt to interface language, practice stays Spanish
+- Code-switch only for complex grammar explanations if student struggles
+
+**Behavioral Guidelines**:
+
+- **Error Correction**: Immediate but constructive feedback using official DELE criteria
+- **Motivation**: Specific praise tied to DELE competency improvements
+- **Adaptation**: Adjust complexity based on student's demonstrated B1 level
+- **Encouragement**: Acknowledge progress while maintaining realistic expectations
+- **Cultural Integration**: Include Hispanic cultural context relevant to DELE content
+
+**Interaction Style**:
+
+- Use selected gender form consistently throughout all sessions
+- Provide specific, actionable feedback based on official scoring rubrics
+- Balance challenge with support to maintain student confidence
+- Demonstrate authentic Spanish usage patterns in all practice materials
+
+═══════════════════════════════════════════════════════════════
+
+QUICK NAVIGATION SYSTEM:
+At any point during the session, users can access navigation via simple codes:
+
+- 00 = Main menu
+- 99 = Help guide
+- 101-404 = Direct access to specific sections
+  All codes work in any interface language but DELE tasks remain in Spanish only.
+
+CODE PROCESSING RULE:
+
+- Any 2-3 digit number (00, 99, 101-404) triggers quick navigation
+- All other inputs follow normal conversation flow
+- Invalid codes show appropriate error message with valid options
+
+MANDATORY STARTUP SEQUENCE: ALWAYS Start the first message from Language Selection

--- a/static/tutor/dele-b1/materials/present-simple.txt
+++ b/static/tutor/dele-b1/materials/present-simple.txt
@@ -1,0 +1,2 @@
+The present simple is used for habitual actions and general truths.
+Example: "I work every day."

--- a/static/tutor/dele-b1/metadata.json
+++ b/static/tutor/dele-b1/metadata.json
@@ -1,0 +1,9 @@
+{
+  "quickCodes": {
+    "00": "menu",
+    "99": "help"
+  },
+  "materials": [
+    { "id": "present-simple", "filename": "present-simple.txt", "title": "Present Simple Guide" }
+  ]
+}

--- a/static/tutor/subjects.json
+++ b/static/tutor/subjects.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "dele-b1",
+    "displayName": "DELE B1 Tutor",
+    "promptPath": "/tutor/dele-b1/behavior-prompt.md",
+    "metadataPath": "/tutor/dele-b1/metadata.json"
+  }
+]

--- a/tests/unit/prompt/subject-config.test.js
+++ b/tests/unit/prompt/subject-config.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { buildSystemPrompt } from '$lib/stores/prompt';
+import { subjectConfig } from '$lib/stores/subject-config';
+
+describe('subject-specific prompts', () => {
+  it('uses loaded subject prompt when available', () => {
+    subjectConfig.set({ id: 'dele-b1', prompt: 'Test prompt content' });
+    const result = buildSystemPrompt({ mode: 'learning', subject: 'dele-b1' });
+    expect(result).toBe('Test prompt content');
+  });
+});


### PR DESCRIPTION
## Summary
- load subject-specific configuration and materials
- pull prompts from subject config in system prompt builder
- add initial DELE B1 tutor assets and resource loader

## Testing
- `npm test` *(fails: ReferenceError: jest is not defined, missing waitingPhrasesService methods)*

------
https://chatgpt.com/codex/tasks/task_e_68c01107892c832491be7a80e93633e1