### PR TITLE
feat: add admin management routes and components

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,20 @@
+import { redirect } from '@sveltejs/kit';
+
+export const handle = async ({ event, resolve }) => {
+  const { url, cookies } = event;
+  const path = url.pathname;
+  const isProtected = path.startsWith('/admin') || path.startsWith('/api/admin');
+  const publicPaths = ['/admin', '/api/admin/login'];
+
+  if (isProtected && !publicPaths.includes(path)) {
+    const session = cookies.get('admin_session', { signed: true });
+    if (!session) {
+      if (path.startsWith('/api/')) {
+        return new Response('Unauthorized', { status: 401 });
+      }
+      throw redirect(303, '/admin');
+    }
+  }
+
+  return resolve(event);
+};

--- a/src/lib/components/admin/MaterialList.svelte
+++ b/src/lib/components/admin/MaterialList.svelte
@@ -1,0 +1,32 @@
+<script>
+  export let subject = '';
+  let materials = [];
+
+  async function load() {
+    if (!subject) return;
+    const res = await fetch(`/api/admin/materials?subject=${encodeURIComponent(subject)}`);
+    if (res.ok) {
+      materials = await res.json();
+    }
+  }
+
+  $: (subject, load());
+
+  async function remove(name) {
+    await fetch('/api/admin/materials', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subject, name })
+    });
+    load();
+  }
+</script>
+
+<div class="space-y-2">
+  <h2 class="font-bold">Materials</h2>
+  <ul class="list-disc pl-4">
+    {#each materials as m}
+      <li>{m} <button class="ml-2 border px-1" on:click={() => remove(m)}>Delete</button></li>
+    {/each}
+  </ul>
+</div>

--- a/src/lib/components/admin/MaterialUpload.svelte
+++ b/src/lib/components/admin/MaterialUpload.svelte
@@ -1,0 +1,28 @@
+<script>
+  export let subject = '';
+  let file;
+
+  async function upload() {
+    if (!file || !subject) return;
+    const form = new FormData();
+    form.append('subject', subject);
+    form.append('file', file);
+    const res = await fetch('/api/admin/materials', {
+      method: 'POST',
+      body: form
+    });
+    if (res.ok) {
+      file = null;
+      dispatch('uploaded');
+    }
+  }
+
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+</script>
+
+<div class="space-y-2">
+  <h2 class="font-bold">Upload Material</h2>
+  <input type="file" on:change={(e) => (file = e.target.files[0])} />
+  <button class="border px-2" on:click={upload}>Upload</button>
+</div>

--- a/src/lib/components/admin/PromptEditor.svelte
+++ b/src/lib/components/admin/PromptEditor.svelte
@@ -1,0 +1,29 @@
+<script>
+  export let subject = '';
+  let prompt = '';
+
+  async function load() {
+    if (!subject) return;
+    const res = await fetch(`/api/admin/prompt?subject=${encodeURIComponent(subject)}`);
+    if (res.ok) {
+      const data = await res.json();
+      prompt = data.prompt || '';
+    }
+  }
+
+  $: (subject, load());
+
+  async function save() {
+    await fetch('/api/admin/prompt', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subject, prompt })
+    });
+  }
+</script>
+
+<div class="space-y-2">
+  <h2 class="font-bold">Prompt Editor</h2>
+  <textarea class="w-full border p-2" rows="5" bind:value={prompt}></textarea>
+  <button class="border px-2" on:click={save}>Save</button>
+</div>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,0 +1,70 @@
+<script>
+  import PromptEditor from '$lib/components/admin/PromptEditor.svelte';
+  import MaterialUpload from '$lib/components/admin/MaterialUpload.svelte';
+  import MaterialList from '$lib/components/admin/MaterialList.svelte';
+
+  let username = '';
+  let password = '';
+  let error = '';
+  let loggedIn = false;
+  let subjects = [];
+  let subject = '';
+
+  async function login() {
+    const res = await fetch('/api/admin/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      loggedIn = true;
+      error = '';
+      await loadSubjects();
+    } else {
+      error = 'Invalid credentials';
+    }
+  }
+
+  async function logout() {
+    await fetch('/api/admin/logout', { method: 'POST' });
+    loggedIn = false;
+    username = '';
+    password = '';
+  }
+
+  async function loadSubjects() {
+    const res = await fetch('/api/admin/subjects');
+    if (res.ok) {
+      subjects = await res.json();
+      subject = subjects[0] || '';
+    }
+  }
+</script>
+
+{#if loggedIn}
+  <div class="p-4 space-y-4">
+    <div>
+      <label class="mr-2" for="subject">Subject:</label>
+      <select id="subject" bind:value={subject} class="border p-1">
+        {#each subjects as s}
+          <option value={s}>{s}</option>
+        {/each}
+      </select>
+      <button class="ml-4 border px-2" on:click={logout}>Logout</button>
+    </div>
+    <PromptEditor {subject} />
+    <MaterialUpload {subject} on:uploaded={loadSubjects} />
+    <MaterialList {subject} />
+  </div>
+{:else}
+  <form class="p-4 space-y-2" on:submit|preventDefault={login}>
+    <div>
+      <input class="border p-1" placeholder="Username" bind:value={username} />
+    </div>
+    <div>
+      <input type="password" class="border p-1" placeholder="Password" bind:value={password} />
+    </div>
+    {#if error}<p class="text-red-500">{error}</p>{/if}
+    <button class="border px-2 py-1" type="submit">Login</button>
+  </form>
+{/if}

--- a/src/routes/api/admin/login/+server.js
+++ b/src/routes/api/admin/login/+server.js
@@ -1,0 +1,15 @@
+import { json } from '@sveltejs/kit';
+
+export async function POST({ request, cookies }) {
+  const { username, password } = await request.json();
+  if (username === 'ADMIN' && password === 'DEMO543') {
+    cookies.set('admin_session', 'active', {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'strict',
+      signed: true
+    });
+    return json({ success: true });
+  }
+  return json({ error: 'Invalid credentials' }, { status: 401 });
+}

--- a/src/routes/api/admin/logout/+server.js
+++ b/src/routes/api/admin/logout/+server.js
@@ -1,0 +1,6 @@
+import { json } from '@sveltejs/kit';
+
+export async function POST({ cookies }) {
+  cookies.delete('admin_session', { path: '/' });
+  return json({ success: true });
+}

--- a/src/routes/api/admin/materials/+server.js
+++ b/src/routes/api/admin/materials/+server.js
@@ -1,0 +1,24 @@
+import { json } from '@sveltejs/kit';
+
+const materials = {};
+
+export async function GET({ url }) {
+  const subject = url.searchParams.get('subject');
+  return json(materials[subject] || []);
+}
+
+export async function POST({ request }) {
+  const form = await request.formData();
+  const subject = form.get('subject');
+  const file = form.get('file');
+  const name = typeof file === 'object' && 'name' in file ? file.name : 'file';
+  materials[subject] = materials[subject] || [];
+  materials[subject].push(name);
+  return json({ success: true });
+}
+
+export async function DELETE({ request }) {
+  const { subject, name } = await request.json();
+  materials[subject] = (materials[subject] || []).filter((n) => n !== name);
+  return json({ success: true });
+}

--- a/src/routes/api/admin/prompt/+server.js
+++ b/src/routes/api/admin/prompt/+server.js
@@ -1,0 +1,14 @@
+import { json } from '@sveltejs/kit';
+
+const prompts = {};
+
+export async function GET({ url }) {
+  const subject = url.searchParams.get('subject');
+  return json({ prompt: prompts[subject] || '' });
+}
+
+export async function PUT({ request }) {
+  const { subject, prompt } = await request.json();
+  prompts[subject] = prompt;
+  return json({ success: true });
+}

--- a/src/routes/api/admin/subjects/+server.js
+++ b/src/routes/api/admin/subjects/+server.js
@@ -1,0 +1,7 @@
+import { json } from '@sveltejs/kit';
+
+const subjects = ['Math', 'Science'];
+
+export async function GET() {
+  return json(subjects);
+}


### PR DESCRIPTION
## Summary
- add protected admin login page with prompt and material management
- implement API endpoints for admin auth, subjects, prompts, and materials
- secure admin paths using session cookie via server hooks

## Testing
- `npm test` *(fails: playWaitingPhrase does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c182f5cd1c83249b921066bb7af09f