### PR TITLE
feat: add consent flow and retrieval cache

### DIFF
--- a/src/lib/components/ChatPane.svelte
+++ b/src/lib/components/ChatPane.svelte
@@ -1,5 +1,66 @@
 <script>
   import ChatInterface from '$lib/modules/chat/components/ChatInterface.svelte';
+  import { consent, gender } from '$lib/stores/session';
+  import ConsentDialog from './setup/ConsentDialog.svelte';
+  import GenderSelect from './setup/GenderSelect.svelte';
+  import LanguageSelect from './setup/LanguageSelect.svelte';
+  import { subjectConfig, loadMaterial } from '$lib/stores/subject-config';
+
+  let drawerOpen = false;
+  let currentMaterial = null;
+  let materialContent = '';
+
+  async function openMaterial(mat) {
+    currentMaterial = mat;
+    if (!mat.filename.endsWith('.pdf')) {
+      materialContent = await loadMaterial(mat.filename);
+    }
+  }
+
+  function pdfSrc() {
+    if (!currentMaterial) return '';
+    return `/pdfjs/web/viewer.html?file=/tutor/${$subjectConfig.id}/materials/${currentMaterial.filename}`;
+  }
 </script>
 
-<ChatInterface showModeToggle={false} />
+<div class="relative flex">
+  <div class="flex-1">
+    {#if !$consent}
+      <LanguageSelect />
+      <ConsentDialog />
+    {:else if !$gender}
+      <GenderSelect />
+    {:else}
+      <ChatInterface showModeToggle={false} />
+    {/if}
+  </div>
+  {#if drawerOpen}
+    <div class="w-64 border-l p-2 overflow-y-auto bg-white">
+      <h3 class="font-bold mb-2">Materials</h3>
+      {#if $subjectConfig?.materials}
+        <ul class="space-y-1">
+          {#each $subjectConfig.materials as m}
+            <li>
+              <button class="text-blue-500" on:click={() => openMaterial(m)}>{m.title}</button>
+            </li>
+          {/each}
+        </ul>
+        {#if currentMaterial}
+          {#if currentMaterial.filename.endsWith('.pdf')}
+            <iframe title="Material PDF" class="w-full h-64 mt-2" src={pdfSrc()}></iframe>
+          {:else}
+            <pre class="mt-2 whitespace-pre-wrap">{materialContent}</pre>
+          {/if}
+        {/if}
+      {:else}
+        <p>No materials available.</p>
+      {/if}
+    </div>
+  {/if}
+  <button
+    class="absolute top-2 right-2 bg-gray-200 p-1 rounded"
+    on:click={() => (drawerOpen = !drawerOpen)}
+  >
+    {drawerOpen ? 'Close' : 'Materials'}
+  </button>
+</div>

--- a/src/lib/components/setup/AssessmentBriefing.svelte
+++ b/src/lib/components/setup/AssessmentBriefing.svelte
@@ -1,0 +1,8 @@
+<script>
+  export let onContinue = () => {};
+</script>
+
+<div class="p-4 border rounded bg-white">
+  <p class="mb-4">Before starting the assessment, please read the instructions carefully.</p>
+  <button class="px-4 py-2 bg-green-600 text-white rounded" on:click={onContinue}>Continue</button>
+</div>

--- a/src/lib/components/setup/ConsentDialog.svelte
+++ b/src/lib/components/setup/ConsentDialog.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { setConsent } from '$lib/stores/session';
+  export let onAgree = () => {};
+  function agree() {
+    setConsent(true);
+    onAgree();
+  }
+</script>
+
+<div class="p-4 border rounded bg-white">
+  <p class="mb-4">Please provide your consent to continue.</p>
+  <button class="px-4 py-2 bg-blue-500 text-white rounded" on:click={agree}>I Agree</button>
+</div>

--- a/src/lib/components/setup/GenderSelect.svelte
+++ b/src/lib/components/setup/GenderSelect.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { setGender } from '$lib/stores/session';
+  function choose(g) {
+    setGender(g);
+  }
+</script>
+
+<div class="p-4 border rounded bg-white">
+  <p class="mb-2">Select your gender</p>
+  <div class="space-x-2">
+    <button class="px-3 py-1 bg-amber-500 text-white rounded" on:click={() => choose('male')}
+      >Male</button
+    >
+    <button class="px-3 py-1 bg-amber-500 text-white rounded" on:click={() => choose('female')}
+      >Female</button
+    >
+  </div>
+</div>

--- a/src/lib/components/setup/LanguageSelect.svelte
+++ b/src/lib/components/setup/LanguageSelect.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { language, setSessionLanguage } from '$lib/stores/session';
+  const options = [
+    { value: 'en', label: 'English' },
+    { value: 'es', label: 'Spanish' },
+    { value: 'ru', label: 'Russian' }
+  ];
+  function change(e) {
+    setSessionLanguage(e.target.value);
+  }
+</script>
+
+<select class="p-2 border rounded" on:change={change} bind:value={$language}>
+  {#each options as opt}
+    <option value={opt.value}>{opt.label}</option>
+  {/each}
+</select>

--- a/src/lib/modules/chat/components/MessageList.svelte
+++ b/src/lib/modules/chat/components/MessageList.svelte
@@ -178,7 +178,8 @@
           {/if}
 
           <div
-            class="flex items-center justify-between text-xs mt-1 {message.type === MESSAGE_TYPES.USER
+            class="flex items-center justify-between text-xs mt-1 {message.type ===
+            MESSAGE_TYPES.USER
               ? 'text-amber-200'
               : message.type === MESSAGE_TYPES.SYSTEM
                 ? $darkMode
@@ -188,7 +189,9 @@
                   ? 'text-gray-400'
                   : 'text-stone-500'}"
           >
-            <span>{message.timestamp}</span>
+            <span>{message.timestamp}</span>{#if message.source === 'rag'}<span
+                class="ml-2 text-purple-500">RAG</span
+              >{/if}
 
             {#if message.type === MESSAGE_TYPES.TUTOR && message.provider && shouldShowProviderInfo()}
               <div class="flex items-center ml-2">

--- a/src/lib/modules/chat/services.js
+++ b/src/lib/modules/chat/services.js
@@ -178,7 +178,10 @@ export async function sendMessage(content, images = [], sessionId = null, provid
 
       console.log('Adding AI response to chat');
       // Add the AI's response to the chat with provider info if available
-      addMessage('tutor', data.response, null, null, { provider: data.provider });
+      addMessage('tutor', data.response, null, null, {
+        provider: data.provider,
+        source: imgRefs.length ? 'rag' : undefined
+      });
 
       // If session storage adapter is available and sessionId is provided, store in session
       if (sessionStorageAdapter && sessionId) {
@@ -248,7 +251,10 @@ export async function sendMessage(content, images = [], sessionId = null, provid
       const data = await response.json();
 
       // Add the AI's response to the chat with provider info if available
-      addMessage('tutor', data.response, null, null, { provider: data.provider });
+      addMessage('tutor', data.response, null, null, {
+        provider: data.provider,
+        source: references.length ? 'rag' : undefined
+      });
 
       // If session storage adapter is available and sessionId is provided, store in session
       if (sessionStorageAdapter && sessionId) {

--- a/src/lib/modules/rag/RetrievalService.js
+++ b/src/lib/modules/rag/RetrievalService.js
@@ -2,6 +2,17 @@ import { EmbeddingService } from './EmbeddingService';
 import { PgVectorStore } from './PgVectorStore';
 
 const MIN_RELEVANCE = parseFloat(import.meta.env.VITE_MIN_RELEVANCE || '0.75');
+const MAX_CACHE = 50;
+const cache = new Map();
+
+function makeKey(subjectId, query) {
+  let hash = 0;
+  for (let i = 0; i < query.length; i++) {
+    hash = (hash << 5) - hash + query.charCodeAt(i);
+    hash |= 0;
+  }
+  return `${subjectId}:${hash}`;
+}
 
 export class RetrievalService {
   constructor({ store = new PgVectorStore(), embedder = new EmbeddingService() } = {}) {
@@ -11,9 +22,22 @@ export class RetrievalService {
 
   async search(subjectId, query, topK = 5) {
     if (!subjectId || !query) return [];
+    const key = makeKey(subjectId, query);
+    if (cache.has(key)) {
+      const value = cache.get(key);
+      cache.delete(key);
+      cache.set(key, value);
+      return value;
+    }
     const embedding = await this.embedder.embed(query);
     const results = await this.store.search(subjectId, embedding, topK);
-    return results.filter((r) => r.score >= MIN_RELEVANCE);
+    const filtered = results.filter((r) => r.score >= MIN_RELEVANCE);
+    cache.set(key, filtered);
+    if (cache.size > MAX_CACHE) {
+      const first = cache.keys().next().value;
+      cache.delete(first);
+    }
+    return filtered;
   }
 }
 

--- a/src/lib/stores/session.js
+++ b/src/lib/stores/session.js
@@ -1,0 +1,36 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+function persisted(key, initial) {
+  const store = writable(initial);
+  if (browser) {
+    const raw = localStorage.getItem(key);
+    if (raw !== null) {
+      try {
+        store.set(JSON.parse(raw));
+      } catch {
+        /* ignore */
+      }
+    }
+    store.subscribe((value) => {
+      localStorage.setItem(key, JSON.stringify(value));
+    });
+  }
+  return store;
+}
+
+export const consent = persisted('consent', false);
+export const gender = persisted('gender', null);
+export const language = persisted('sessionLanguage', 'en');
+
+export function setConsent(value) {
+  consent.set(value);
+}
+
+export function setGender(value) {
+  gender.set(value);
+}
+
+export function setSessionLanguage(value) {
+  language.set(value);
+}

--- a/src/lib/utils/codeHandler.js
+++ b/src/lib/utils/codeHandler.js
@@ -1,0 +1,7 @@
+export async function handleCode(code, subjectId) {
+  if (typeof code !== 'string' || !/^[0-9]+$/.test(code)) return null;
+  const res = await fetch(`/tutor/${subjectId}/metadata.json`);
+  if (!res.ok) return null;
+  const meta = await res.json();
+  return meta.quickCodes ? meta.quickCodes[code] || null : null;
+}

--- a/src/routes/api/admin/subjects/[id]/materials/[filename]/+server.js
+++ b/src/routes/api/admin/subjects/[id]/materials/[filename]/+server.js
@@ -3,9 +3,19 @@ import fs from 'fs/promises';
 import path from 'path';
 import { removeFile } from '$lib/modules/rag/ingest.js';
 
-export async function DELETE({ params }) {
+async function logAdmin(message) {
+  await fs.appendFile('logs/admin.log', `[${new Date().toISOString()}] ${message}\n`);
+}
+
+export async function DELETE({ params, request }) {
+  const token = request.headers.get('x-csrf-token');
+  if (token !== process.env.CSRF_TOKEN) {
+    await logAdmin('CSRF failure on delete');
+    return json({ error: 'Forbidden' }, { status: 403 });
+  }
   const filePath = path.resolve(`static/tutor/${params.id}/materials/${params.filename}`);
   await fs.unlink(filePath);
   await removeFile(params.id, params.filename);
+  await logAdmin(`deleted ${params.filename} from ${params.id}`);
   return json({ success: true });
 }

--- a/tests/unit/admin/csrf.test.js
+++ b/tests/unit/admin/csrf.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('$lib/modules/rag/ingest.js', () => ({ ingestFile: vi.fn() }));
+import { POST } from '../../../src/routes/api/admin/subjects/[id]/materials/+server.js';
+
+process.env.CSRF_TOKEN = 'token';
+
+describe('admin CSRF', () => {
+  it('rejects missing token', async () => {
+    const file = new File(['a'], 'a.txt', { type: 'text/plain' });
+    const form = new FormData();
+    form.append('file', file);
+    const res = await POST({
+      params: { id: 'math' },
+      request: { headers: new Headers(), formData: async () => form }
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/rag/cache.test.js
+++ b/tests/unit/rag/cache.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { RetrievalService } from '$lib/modules/rag/RetrievalService';
+
+class CountingStore {
+  constructor() {
+    this.calls = 0;
+  }
+  async search() {
+    this.calls++;
+    return [{ score: 1 }];
+  }
+}
+class MockEmbed {
+  async embed() {
+    return [1];
+  }
+}
+
+describe('RetrievalService cache', () => {
+  it('caches by subject and query', async () => {
+    const store = new CountingStore();
+    const rs = new RetrievalService({ store, embedder: new MockEmbed() });
+    await rs.search('math', 'hello');
+    await rs.search('math', 'hello');
+    expect(store.calls).toBe(1);
+  });
+});

--- a/tests/unit/session/consent.test.js
+++ b/tests/unit/session/consent.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { consent, gender, setConsent, setGender } from '$lib/stores/session';
+import { get } from 'svelte/store';
+
+describe('session store', () => {
+  it('stores consent and gender', () => {
+    setConsent(true);
+    setGender('female');
+    expect(get(consent)).toBe(true);
+    expect(get(gender)).toBe('female');
+  });
+});

--- a/tests/unit/utils/codeHandler.test.js
+++ b/tests/unit/utils/codeHandler.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleCode } from '$lib/utils/codeHandler';
+
+describe('codeHandler', () => {
+  it('maps numeric codes', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ quickCodes: { 12: 'menu' } }) });
+    const action = await handleCode('12', 'abc');
+    expect(action).toBe('menu');
+  });
+});


### PR DESCRIPTION
## Summary
- gate chat behind consent and gender selection with new setup components and material viewer
- tag RAG responses and cache retrievals with LRU to reuse results
- require CSRF token for admin uploads/deletes and log admin/ingest events

## Testing
- `npm test` *(fails: voice chat integration and e2e tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b11d67e48324a68598163d931d4b