### PR TITLE
feat(rag): implement tiktoken-based chunking with overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sveltekit-tutor-site",
       "version": "1.0.0",
       "dependencies": {
+        "@dqbd/tiktoken": "^1.0.22",
         "@tensorflow-models/face-landmarks-detection": "^1.0.6",
         "@tensorflow/tfjs": "^4.22.0",
         "face-api.js": "^0.22.2",
@@ -586,6 +587,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dqbd/tiktoken": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-1.0.22.tgz",
+      "integrity": "sha512-RYhO8xeHkMNX5Ixqf4M1Ve3siCYJY/dI0yLnlX4M4oIEDOvjMIQ+E+3OUpAaZcWTaMtQJzGcDAghYfllpx3i/w==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "vitest": "^1.0.4"
   },
   "dependencies": {
+    "@dqbd/tiktoken": "^1.0.22",
     "@tensorflow-models/face-landmarks-detection": "^1.0.6",
     "@tensorflow/tfjs": "^4.22.0",
     "face-api.js": "^0.22.2",

--- a/src/lib/modules/rag/chunk.js
+++ b/src/lib/modules/rag/chunk.js
@@ -1,19 +1,24 @@
+import { encoding_for_model } from '@dqbd/tiktoken';
+
+const decoder = new TextDecoder();
+
 export function chunkText(text, chunkSize = 500, overlap = 50) {
-  const tokens = text.split(/\s+/);
+  const encoder = encoding_for_model('gpt-3.5-turbo');
+  const tokens = encoder.encode(text);
   const chunks = [];
   let start = 0;
 
-  // Guard to avoid non-progress if overlap >= chunkSize
-  const safeOverlap = Math.min(overlap, Math.max(0, chunkSize - 1));
+  const safeOverlap = Math.min(Math.max(overlap, 0), chunkSize - 1);
 
   while (start < tokens.length) {
     const end = Math.min(start + chunkSize, tokens.length);
     const chunkTokens = tokens.slice(start, end);
-    chunks.push(chunkTokens.join(' ').trim());
+    chunks.push(decoder.decode(encoder.decode(chunkTokens)));
     if (end === tokens.length) break;
     start = end - safeOverlap;
-    if (start < 0) start = 0;
   }
+
+  encoder.free();
   return chunks;
 }
 
@@ -43,11 +48,11 @@ export function chunkByHeading(text) {
 }
 
 export function chunkMarkdown(text, chunkSize = 500, overlap = 50) {
+  const encoder = encoding_for_model('gpt-3.5-turbo');
   const sections = chunkByHeading(text);
   const results = [];
 
-  // Guard to keep overlap reasonable relative to chunkSize
-  const safeOverlap = Math.max(0, Math.min(overlap, chunkSize - 1));
+  const safeOverlap = Math.min(Math.max(overlap, 0), chunkSize - 1);
 
   for (const { heading, text: sectionText } of sections) {
     const paragraphs = sectionText
@@ -55,38 +60,43 @@ export function chunkMarkdown(text, chunkSize = 500, overlap = 50) {
       .map((p) => p.trim())
       .filter(Boolean);
 
-    let current = [];
-    let tokenCounts = [];
-    let tokensInChunk = 0;
+    const paragraphTokens = [];
+    const boundaries = [];
+    let running = 0;
+    for (let i = 0; i < paragraphs.length; i++) {
+      const tokens = Array.from(encoder.encode(paragraphs[i]));
+      paragraphTokens.push(tokens);
+      running += tokens.length;
+      boundaries.push(running);
+      if (i < paragraphs.length - 1) {
+        const sep = Array.from(encoder.encode('\n\n'));
+        paragraphTokens.push(sep);
+        running += sep.length;
+      }
+    }
+    const allTokens = paragraphTokens.flat();
 
-    for (const para of paragraphs) {
-      const tokens = para.split(/\s+/);
-      const count = tokens.length;
-
-      if (tokensInChunk + count > chunkSize && tokensInChunk > 0) {
-        results.push({ heading, text: current.join('\n\n') });
-
-        // Build overlap using whole paragraphs from the end
-        let overlapParas = [];
-        let overlapTokens = 0;
-        for (let i = current.length - 1; i >= 0 && overlapTokens < safeOverlap; i--) {
-          overlapParas.unshift(current[i]);
-          overlapTokens += tokenCounts[i];
-        }
-        current = overlapParas.slice();
-        tokenCounts = overlapParas.map((p) => p.split(/\s+/).length);
-        tokensInChunk = overlapTokens;
+    let start = 0;
+    const total = allTokens.length;
+    while (start < total) {
+      let end = Math.min(start + chunkSize, total);
+      let boundary = null;
+      for (const b of boundaries) {
+        if (b > start && b <= end) boundary = b;
+        if (b > end) break;
+      }
+      if (boundary && boundary - start >= chunkSize * 0.5) {
+        end = boundary;
       }
 
-      current.push(para);
-      tokenCounts.push(count);
-      tokensInChunk += count;
-    }
-
-    if (current.length) {
-      results.push({ heading, text: current.join('\n\n') });
+      const chunkTokens = allTokens.slice(start, end);
+      const decoded = encoder.decode(new Uint32Array(chunkTokens));
+      results.push({ heading, text: decoder.decode(decoded) });
+      if (end === total) break;
+      start = end - safeOverlap;
     }
   }
 
+  encoder.free();
   return results;
 }

--- a/tests/unit/rag/chunk.test.js
+++ b/tests/unit/rag/chunk.test.js
@@ -1,12 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { chunkText } from '$lib/modules/rag/chunk';
+import { encoding_for_model } from '@dqbd/tiktoken';
 
 describe('chunkText', () => {
-  it('splits text with overlap', () => {
-    const text = Array.from({ length: 1200 }, (_, i) => `w${i}`).join(' ');
+  it('splits text with token overlap', () => {
+    const text = Array.from({ length: 1200 }, () => 'a').join(' ');
     const chunks = chunkText(text, 500, 50);
     expect(chunks.length).toBe(3);
-    expect(chunks[0].split(/\s+/).length).toBe(500);
-    expect(chunks[1].split(/\s+/)[0]).toBe('w450');
+
+    const enc = encoding_for_model('gpt-3.5-turbo');
+    const firstTokens = Array.from(enc.encode(chunks[0]));
+    const secondTokens = Array.from(enc.encode(chunks[1]));
+    expect(firstTokens.length).toBe(500);
+    expect(firstTokens.slice(-50)).toEqual(secondTokens.slice(0, 50));
+    enc.free();
   });
 });

--- a/tests/unit/rag/headingChunker.test.js
+++ b/tests/unit/rag/headingChunker.test.js
@@ -12,14 +12,22 @@ describe('chunkByHeading', () => {
 });
 
 describe('chunkMarkdown', () => {
-  it('respects headings and overlap', () => {
-    const p1 = Array.from({ length: 10 }, (_, i) => `a${i}`).join(' ');
-    const p2 = Array.from({ length: 10 }, (_, i) => `b${i}`).join(' ');
+  it('preserves headings in all chunks', () => {
+    const p1 = Array.from({ length: 150 }, () => 'a').join(' ');
+    const p2 = Array.from({ length: 150 }, () => 'b').join(' ');
     const md = `# H1\n${p1}\n\n${p2}`;
-    const chunks = chunkMarkdown(md, 15, 5);
-    expect(chunks).toHaveLength(2);
-    expect(chunks[0].heading).toBe('H1');
-    expect(chunks[1].text.startsWith(p1)).toBe(true);
-    expect(chunks[1].text).toContain(p2);
+    const chunks = chunkMarkdown(md, 200, 50);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((c) => c.heading === 'H1')).toBe(true);
+  });
+
+  it('maintains 50 token overlap', () => {
+    const p1 = Array.from({ length: 150 }, () => 'a').join(' ');
+    const p2 = Array.from({ length: 150 }, () => 'b').join(' ');
+    const md = `# H1\n${p1}\n\n${p2}`;
+    const chunks = chunkMarkdown(md, 200, 50);
+    const firstWords = chunks[0].text.trim().split(/\s+/);
+    const secondWords = chunks[1].text.trim().split(/\s+/);
+    expect(firstWords.slice(-50)).toEqual(secondWords.slice(0, 50));
   });
 });


### PR DESCRIPTION
## Summary
- integrate @dqbd/tiktoken to tokenize text for chunking
- ensure markdown chunking respects headings and paragraph boundaries with 50-token overlaps
- add unit tests for token overlap and heading preservation

## Testing
- `npm run test:run tests/unit/rag/chunk.test.js tests/unit/rag/headingChunker.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1ad87ca708324a2a389432d74f661