### PR TITLE
feat: add user login page

### DIFF
--- a/src/lib/modules/auth/services/LocalAuthService.js
+++ b/src/lib/modules/auth/services/LocalAuthService.js
@@ -1,11 +1,11 @@
-import { API_ENDPOINTS, STORAGE_KEYS } from '$shared/utils/constants';
+import { STORAGE_KEYS } from '$shared/utils/constants';
 import { user, isAuthenticated } from '../stores';
 import { setLoading, setError, setNotification } from '$lib/stores/app';
 import { IAuthService } from '../interfaces/IAuthService';
 
 /**
  * Local Authentication Service
- * 
+ *
  * This class implements the IAuthService interface for local authentication.
  * It simulates authentication with hardcoded users for demonstration purposes.
  */
@@ -19,7 +19,7 @@ export class LocalAuthService extends IAuthService {
   async login(email, password) {
     try {
       setLoading(true);
-      
+
       // In a real implementation, this would be an API call
       // const response = await fetch(API_ENDPOINTS.AUTH.LOGIN, {
       //   method: 'POST',
@@ -28,36 +28,53 @@ export class LocalAuthService extends IAuthService {
       //   },
       //   body: JSON.stringify({ email, password })
       // });
-      
+
       // if (!response.ok) {
       //   throw new Error('Invalid credentials');
       // }
-      
+
       // const data = await response.json();
       // user.set(data.user);
       // isAuthenticated.set(true);
       // localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, data.token);
       // localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(data.user));
-      
+
       // Simulate API call for demonstration
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       // Simulate login for demo users
-      if (email === 'admin@example.com' && password === 'password') {
+      if (email?.toUpperCase() === 'ADMIN' && password === 'Demo543') {
+        const userData = {
+          id: 0,
+          name: 'Admin User',
+          email: 'admin',
+          role: 'admin'
+        };
+
+        user.set(userData);
+        isAuthenticated.set(true);
+
+        // Store in localStorage for persistence
+        localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(userData));
+        localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, 'mock-jwt-token-for-admin');
+
+        setNotification('Logged in successfully', 'success');
+        return userData;
+      } else if (email === 'admin@example.com' && password === 'password') {
         const userData = {
           id: 1,
           name: 'Admin User',
           email: 'admin@example.com',
           role: 'admin'
         };
-        
+
         user.set(userData);
         isAuthenticated.set(true);
-        
+
         // Store in localStorage for persistence
         localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(userData));
         localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, 'mock-jwt-token-for-admin');
-        
+
         setNotification('Logged in successfully', 'success');
         return userData;
       } else if (email === 'student@example.com' && password === 'password') {
@@ -67,14 +84,14 @@ export class LocalAuthService extends IAuthService {
           email: 'student@example.com',
           role: 'student'
         };
-        
+
         user.set(userData);
         isAuthenticated.set(true);
-        
+
         // Store in localStorage for persistence
         localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(userData));
         localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, 'mock-jwt-token-for-student');
-        
+
         setNotification('Logged in successfully', 'success');
         return userData;
       } else {
@@ -88,7 +105,7 @@ export class LocalAuthService extends IAuthService {
       setLoading(false);
     }
   }
-  
+
   /**
    * Register new user
    * @param {Object} userData - User registration data
@@ -97,7 +114,7 @@ export class LocalAuthService extends IAuthService {
   async register(userData) {
     try {
       setLoading(true);
-      
+
       // In a real implementation, this would be an API call
       // const response = await fetch(API_ENDPOINTS.AUTH.REGISTER, {
       //   method: 'POST',
@@ -106,18 +123,18 @@ export class LocalAuthService extends IAuthService {
       //   },
       //   body: JSON.stringify(userData)
       // });
-      
+
       // if (!response.ok) {
       //   throw new Error('Registration failed');
       // }
-      
+
       // const data = await response.json();
       // setNotification('Registration successful. Please log in.', 'success');
       // return data.user;
-      
+
       // Simulate API call for demonstration
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
       // Simulate successful registration
       setNotification('Registration successful. Please log in.', 'success');
       return {
@@ -134,7 +151,7 @@ export class LocalAuthService extends IAuthService {
       setLoading(false);
     }
   }
-  
+
   /**
    * Logout user
    * @returns {Promise<boolean>} - Promise that resolves when logout is complete
@@ -142,7 +159,7 @@ export class LocalAuthService extends IAuthService {
   async logout() {
     try {
       setLoading(true);
-      
+
       // In a real implementation, this would be an API call
       // const response = await fetch(API_ENDPOINTS.AUTH.LOGOUT, {
       //   method: 'POST',
@@ -150,16 +167,16 @@ export class LocalAuthService extends IAuthService {
       //     'Authorization': `Bearer ${localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN)}`
       //   }
       // });
-      
+
       // Clear user data regardless of API response
       user.set(null);
       isAuthenticated.set(false);
       localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
       localStorage.removeItem(STORAGE_KEYS.USER);
-      
+
       // Simulate API call for demonstration
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       setNotification('Logged out successfully', 'info');
       return true;
     } catch (error) {
@@ -174,7 +191,7 @@ export class LocalAuthService extends IAuthService {
       setLoading(false);
     }
   }
-  
+
   /**
    * Check if user is authenticated
    * @returns {boolean} - True if user is authenticated
@@ -183,7 +200,7 @@ export class LocalAuthService extends IAuthService {
     try {
       const storedUser = localStorage.getItem(STORAGE_KEYS.USER);
       const token = localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN);
-      
+
       if (storedUser && token) {
         try {
           const userData = JSON.parse(storedUser);
@@ -196,7 +213,7 @@ export class LocalAuthService extends IAuthService {
           return false;
         }
       }
-      
+
       return false;
     } catch (error) {
       console.error('Auth check error:', error);

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -2,12 +2,12 @@
   import { goto } from '$app/navigation';
   import { login as loginService } from '$modules/auth/services';
 
-  let email = '';
+  let username = '';
   let password = '';
   let error = '';
 
   async function submit() {
-    const res = await loginService(email, password);
+    const res = await loginService(username, password);
     if (res) {
       error = '';
       goto('/');
@@ -19,7 +19,7 @@
 
 <h1>Sign In</h1>
 <form on:submit|preventDefault={submit}>
-  <input type="email" placeholder="Email" bind:value={email} />
+  <input type="text" placeholder="Email or Username" bind:value={username} />
   <input type="password" placeholder="Password" bind:value={password} />
   <button type="submit">Sign In</button>
   {#if error}<p>{error}</p>{/if}

--- a/tests/unit/admin/login.test.js
+++ b/tests/unit/admin/login.test.js
@@ -27,6 +27,13 @@ describe('LocalAuthService login', () => {
     expect(localStorage.setItem).toHaveBeenCalled();
   });
 
+  it('logs in with ADMIN predefined credentials', async () => {
+    const svc = new LocalAuthService();
+    const res = await svc.login('ADMIN', 'Demo543');
+    expect(res.role).toBe('admin');
+    expect(localStorage.setItem).toHaveBeenCalled();
+  });
+
   it('fails with invalid credentials', async () => {
     const svc = new LocalAuthService();
     const res = await svc.login('bad', 'creds');

--- a/tests/unit/auth/loginPage.test.js
+++ b/tests/unit/auth/loginPage.test.js
@@ -24,15 +24,15 @@ describe('LoginPage', () => {
 
     const { getByPlaceholderText, getByRole } = render(LoginPage);
 
-    await fireEvent.input(getByPlaceholderText('Email'), {
-      target: { value: 'admin@example.com' }
+    await fireEvent.input(getByPlaceholderText('Email or Username'), {
+      target: { value: 'ADMIN' }
     });
     await fireEvent.input(getByPlaceholderText('Password'), {
-      target: { value: 'password' }
+      target: { value: 'Demo543' }
     });
     await fireEvent.click(getByRole('button', { name: /Sign In/i }));
 
-    expect(login).toHaveBeenCalledWith('admin@example.com', 'password');
+    expect(login).toHaveBeenCalledWith('ADMIN', 'Demo543');
     await waitFor(() => {
       expect(goto).toHaveBeenCalledWith('/');
     });


### PR DESCRIPTION
## Summary
- add sign-in page wired to LocalAuthService
- cover sign-in flow with unit test

## Testing
- `npm test` *(fails: modules missing, etc.)*
- `npm test tests/unit/auth/loginPage.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1b97cd71c8324ae5201b5fcc32ba4