### PR TITLE
fix: register LLM provider and avoid node crypto in browser

### DIFF
--- a/src/lib/modules/rag/PgVectorStore.js
+++ b/src/lib/modules/rag/PgVectorStore.js
@@ -1,4 +1,48 @@
-import { randomUUID } from 'crypto';
+/* global globalThis */
+// Use Web Crypto API when available to avoid bundling Node's crypto module
+function generateId() {
+  if (typeof globalThis.crypto !== 'undefined') {
+    if (typeof globalThis.crypto.randomUUID === 'function') {
+      return globalThis.crypto.randomUUID();
+    }
+    if (typeof globalThis.crypto.getRandomValues === 'function') {
+      const bytes = new Uint8Array(16);
+      globalThis.crypto.getRandomValues(bytes);
+      // RFC4122 version 4 UUID
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const toHex = (n) => n.toString(16).padStart(2, '0');
+      return (
+        toHex(bytes[0]) +
+        toHex(bytes[1]) +
+        toHex(bytes[2]) +
+        toHex(bytes[3]) +
+        '-' +
+        toHex(bytes[4]) +
+        toHex(bytes[5]) +
+        '-' +
+        toHex(bytes[6]) +
+        toHex(bytes[7]) +
+        '-' +
+        toHex(bytes[8]) +
+        toHex(bytes[9]) +
+        '-' +
+        toHex(bytes[10]) +
+        toHex(bytes[11]) +
+        toHex(bytes[12]) +
+        toHex(bytes[13]) +
+        toHex(bytes[14]) +
+        toHex(bytes[15])
+      );
+    }
+  }
+  // Fallback using Math.random (not cryptographically secure)
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
 
 export class PgVectorStore {
   constructor(connectionString = process.env.DATABASE_URL) {
@@ -23,7 +67,7 @@ export class PgVectorStore {
       const query =
         'INSERT INTO chunks(subject_id, chunk_id, embedding, metadata) VALUES($1,$2,$3,$4) ON CONFLICT (chunk_id) DO UPDATE SET embedding = EXCLUDED.embedding, metadata = EXCLUDED.metadata';
       for (const chunk of chunks) {
-        const id = chunk.id || randomUUID();
+        const id = chunk.id || generateId();
         await client.query(query, [subjectId, id, chunk.embedding, chunk.metadata]);
       }
     } finally {


### PR DESCRIPTION
## Summary
- register LLM ProviderManager on both server and client
- replace Node `crypto` import with browser-compatible UUID generation in PgVectorStore

## Testing
- `npm test` *(fails: Error: Failed to resolve import "@dqbd/tiktoken"; Error: OPENAI_API_KEY not set; and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d1b0af708324a36ab5f799872148