### PR TITLE
Add Learn mode with authentication gating and navigation toggle

### DIFF
--- a/src/lib/modules/chat/components/ChatInterface.svelte
+++ b/src/lib/modules/chat/components/ChatInterface.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  import { MessageCircle, Mic, Globe, RotateCcw, Server } from 'lucide-svelte';
+  import { MessageCircle, Mic, Globe, RotateCcw } from 'lucide-svelte';
   import {
     chatMode,
     messages,
@@ -26,6 +26,7 @@
   import VoiceChat from './VoiceChat.svelte';
   import Button from '$shared/components/Button.svelte';
   import { browser } from '$app/environment';
+  import { appMode } from '$lib/stores/mode';
 
   // Session ID for maintaining conversation context
   let sessionId;
@@ -35,7 +36,6 @@
   // Provider selection
   let selectedProvider = null;
   let availableProviders = [];
-  let showProviderSelector = false;
 
   // Get available providers on mount
   onMount(async () => {
@@ -54,7 +54,8 @@
   // Initialize chat when language is selected
   $: if ($selectedLanguage && $messages.length === 0) {
     const welcomeMessage = getTranslation($selectedLanguage, 'welcomeMessage');
-    initializeChat(welcomeMessage);
+    const modeNote = $appMode === 'learn' ? 'You are in Learn mode.' : 'You are in Fun mode.';
+    initializeChat(`${welcomeMessage} ${modeNote}`);
   }
 
   // Process images for a message
@@ -182,7 +183,7 @@
       // Load chat history from session if available
       if (sessionId && $messages.length === 0) {
         import('../services').then(({ getChatHistory }) => {
-          getChatHistory(sessionId).then(history => {
+          getChatHistory(sessionId).then((history) => {
             if (history && history.length > 0) {
               console.log('Loaded chat history from session:', history.length, 'messages');
               // Replace messages store with history

--- a/src/lib/modules/navigation/components/Navigation.svelte
+++ b/src/lib/modules/navigation/components/Navigation.svelte
@@ -4,17 +4,18 @@
   import { getTranslation } from '$modules/i18n/translations';
   import ThemeToggle from '$modules/theme/components/ThemeToggle.svelte';
   import AuthButton from '$modules/auth/components/AuthButton.svelte';
-  import LanguageSelector from '$modules/i18n/components/LanguageSelector.svelte';
+  import { appMode, requireAuth } from '$lib/stores/mode';
 
   let mobileMenuOpen = false;
-  let showLanguageSelector = false;
 
   function toggleMobileMenu() {
     mobileMenuOpen = !mobileMenuOpen;
   }
 </script>
 
-<nav class="dark:bg-gray-800 dark:border-gray-700 bg-white border-stone-200 shadow-sm border-b sticky top-0 z-50">
+<nav
+  class="dark:bg-gray-800 dark:border-gray-700 bg-white border-stone-200 shadow-sm border-b sticky top-0 z-50"
+>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center h-16">
       <div class="flex items-center">
@@ -26,10 +27,34 @@
 
       <!-- Desktop Menu -->
       <div class="hidden md:flex items-center space-x-8">
-        <a href="/about" class="dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 transition-colors">
+        <button
+          on:click={() => requireAuth('fun')}
+          class="dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 transition-colors {$appMode ===
+          'fun'
+            ? 'font-bold underline'
+            : ''}"
+        >
+          Fun
+        </button>
+        <button
+          on:click={() => requireAuth('learn')}
+          class="dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 transition-colors {$appMode ===
+          'learn'
+            ? 'font-bold underline'
+            : ''}"
+        >
+          Learn
+        </button>
+        <a
+          href="/about"
+          class="dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 transition-colors"
+        >
           {getTranslation($selectedLanguage, 'about')}
         </a>
-        <a href="/contacts" class="dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 transition-colors">
+        <a
+          href="/contacts"
+          class="dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 transition-colors"
+        >
           {getTranslation($selectedLanguage, 'contacts')}
         </a>
         <ThemeToggle />
@@ -58,10 +83,40 @@
   {#if mobileMenuOpen}
     <div class="md:hidden dark:bg-gray-800 dark:border-gray-700 bg-white border-stone-200 border-t">
       <div class="px-2 pt-2 pb-3 space-y-1">
-        <a href="/about" class="block px-3 py-2 dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700">
+        <button
+          on:click={() => {
+            requireAuth('fun');
+            mobileMenuOpen = false;
+          }}
+          class="block px-3 py-2 w-full text-left dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 {$appMode ===
+          'fun'
+            ? 'font-bold underline'
+            : ''}"
+        >
+          Fun
+        </button>
+        <button
+          on:click={() => {
+            requireAuth('learn');
+            mobileMenuOpen = false;
+          }}
+          class="block px-3 py-2 w-full text-left dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 {$appMode ===
+          'learn'
+            ? 'font-bold underline'
+            : ''}"
+        >
+          Learn
+        </button>
+        <a
+          href="/about"
+          class="block px-3 py-2 dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700"
+        >
           {getTranslation($selectedLanguage, 'about')}
         </a>
-        <a href="/contacts" class="block px-3 py-2 dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700">
+        <a
+          href="/contacts"
+          class="block px-3 py-2 dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700"
+        >
           {getTranslation($selectedLanguage, 'contacts')}
         </a>
         <div class="px-3 py-2">
@@ -70,5 +125,4 @@
       </div>
     </div>
   {/if}
-
 </nav>

--- a/src/lib/stores/mode.js
+++ b/src/lib/stores/mode.js
@@ -1,0 +1,25 @@
+import { writable, get } from 'svelte/store';
+import { isAuthenticated } from '$modules/auth/stores';
+import { goto } from '$app/navigation';
+
+const stored = typeof localStorage !== 'undefined' ? localStorage.getItem('appMode') : null;
+export const appMode = writable(stored || 'fun');
+
+appMode.subscribe((mode) => {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('appMode', mode);
+  }
+});
+
+export function setMode(mode) {
+  appMode.set(mode);
+}
+
+export function requireAuth(mode) {
+  if (mode === 'learn' && !get(isAuthenticated)) {
+    goto('/login?redirect=/learn');
+    return;
+  }
+  setMode(mode);
+  goto(mode === 'learn' ? '/learn' : '/');
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,10 +2,12 @@
   import { onMount } from 'svelte';
   import ChatInterface from '$modules/chat/components/ChatInterface.svelte';
   import { checkAuth } from '$modules/auth/stores';
+  import { setMode } from '$lib/stores/mode';
 
-  // Check if user is already logged in
+  // Check if user is already logged in and set fun mode
   onMount(() => {
     checkAuth();
+    setMode('fun');
   });
 </script>
 

--- a/src/routes/learn/+page.svelte
+++ b/src/routes/learn/+page.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { onMount } from 'svelte';
+  import ChatInterface from '$modules/chat/components/ChatInterface.svelte';
+  import { checkAuth, isAuthenticated } from '$modules/auth/stores';
+  import { setMode } from '$lib/stores/mode';
+  import { goto } from '$app/navigation';
+
+  onMount(() => {
+    checkAuth();
+    const unsubscribe = isAuthenticated.subscribe((authed) => {
+      if (!authed) {
+        goto('/login?redirect=/learn');
+      } else {
+        setMode('learn');
+      }
+    });
+    return unsubscribe;
+  });
+</script>
+
+<div class="min-h-screen">
+  <h1 class="sr-only">Learn Mode</h1>
+  <div class="max-w-4xl mx-auto px-4 py-8">
+    <ChatInterface />
+  </div>
+</div>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,10 +1,15 @@
 <script>
   import { login } from '$modules/auth/stores';
   import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { setMode } from '$lib/stores/mode';
   let email = '';
   let password = '';
   let remember = false;
   let error = '';
+  let redirect = '/';
+
+  $: redirect = $page.url.searchParams.get('redirect') || '/';
 
   async function handleSignIn() {
     error = '';
@@ -14,7 +19,8 @@
     }
     try {
       await login(email, password);
-      goto('/');
+      setMode(redirect === '/learn' ? 'learn' : 'fun');
+      goto(redirect);
     } catch (e) {
       error = 'Invalid credentials';
     }


### PR DESCRIPTION
## Summary
- Introduce persistent appMode store with helper to guard Learn mode behind auth
- Add Fun/Learn switches to navigation with active-mode highlighting
- Redirect login based on redirect query and wire new /learn route

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4ffc90bbc8324af2dc0d1bb420aec