### PR TITLE
Await session sessionStorageAdapter before returning

### DIFF
--- a/src/lib/modules/chat/services.js
+++ b/src/lib/modules/chat/services.js
@@ -12,6 +12,11 @@ import {
 } from '$lib/config/api.js';
 import { waitingPhrasesService } from './waitingPhrasesService.js';
 
+// Helper to synchronously store a conversation turn in session memory
+function storeConversation(adapter, sessionId, message, reply) {
+  return adapter.handleUserMessage(message, sessionId, () => reply);
+}
+
 /**
  * Display a waiting phrase sentence by sentence.
  * Each sentence is emitted as a separate message bubble with its own ID.
@@ -218,11 +223,7 @@ export async function sendMessage(
       if (sessionStorageAdapter && sessionId) {
         console.log(`[Session] Storing conversation in session ${sessionId}`);
         // Store user message
-        sessionStorageAdapter.handleUserMessage(content, sessionId, async (message, context) => {
-          console.log(`[Session] Generating response for message: ${message}`);
-          console.log(`[Session] Using context:`, context);
-          return data.response;
-        });
+        await storeConversation(sessionStorageAdapter, sessionId, content, data.response);
       }
 
       // If OCR text was returned, update the original message with it
@@ -290,11 +291,7 @@ export async function sendMessage(
       if (sessionStorageAdapter && sessionId) {
         console.log(`[Session] Storing conversation in session ${sessionId}`);
         // Store user message
-        sessionStorageAdapter.handleUserMessage(content, sessionId, async (message, context) => {
-          console.log(`[Session] Generating response for message: ${message}`);
-          console.log(`[Session] Using context:`, context);
-          return data.response;
-        });
+        await storeConversation(sessionStorageAdapter, sessionId, content, data.response);
       }
 
       return true;

--- a/tests/session/sequentialMessages.test.js
+++ b/tests/session/sequentialMessages.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { writable } from 'svelte/store';
+
+vi.mock('../../src/lib/modules/chat/waitingPhrasesService.js', () => ({
+  waitingPhrasesService: {
+    selectWaitingPhrase: vi.fn().mockResolvedValue('...')
+  }
+}));
+
+vi.mock('../../src/lib/modules/chat/voiceServices.js', () => ({
+  synthesizeWaitingPhrase: vi.fn().mockResolvedValue()
+}));
+
+vi.mock('$lib/stores/app', () => ({
+  setLoading: vi.fn(),
+  setError: vi.fn()
+}));
+
+vi.mock('$modules/i18n/stores', () => ({
+  selectedLanguage: writable('en')
+}));
+
+import { sendMessage } from '../../src/lib/modules/chat/services.js';
+import { container } from '../../src/lib/shared/di/container.js';
+import { SessionFactory } from '../../src/lib/modules/session/SessionFactory.js';
+import { SessionStorageAdapter } from '../../src/lib/modules/session/SessionStorageAdapter.js';
+
+describe('sendMessage session updates', () => {
+  beforeEach(() => {
+    container.clear();
+  });
+
+  it('includes previous turn when messages are sent sequentially', async () => {
+    const sessionFactory = new SessionFactory();
+    const adapter = new SessionStorageAdapter(sessionFactory);
+    container.register('sessionFactory', sessionFactory);
+    container.register('sessionStorageAdapter', adapter);
+
+    const sessionId = 'abc';
+
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ response: 'Hi there', provider: 'mock' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ response: 'Doing well', provider: 'mock' })
+      });
+
+    await sendMessage('Hello', [], sessionId);
+    await sendMessage('How are you?', [], sessionId);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(fetch.mock.calls[1][1].body);
+    expect(secondBody.sessionContext.history).toHaveLength(2);
+    expect(secondBody.sessionContext.history[0].content).toBe('Hello');
+    expect(secondBody.sessionContext.history[1].content).toBe('Hi there');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure chat service awaits session storage updates
- add sequential message regression test

## Testing
- `npm test`
- `npm run test:run tests/session`


------
https://chatgpt.com/codex/tasks/task_e_68c734a9456483248a49b16736092b7e