### PR TITLE
Fix mode toggle colors for fun/learn buttons

### DIFF
--- a/src/lib/modules/navigation/components/ModeToggle.svelte
+++ b/src/lib/modules/navigation/components/ModeToggle.svelte
@@ -11,18 +11,15 @@
 </script>
 
 <div
-  class={`relative flex items-center rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden
+  class={`relative flex items-center rounded-full bg-[#d3d3d3] dark:bg-gray-700 overflow-hidden
     ${size === 'compact' ? 'w-24 h-8' : 'w-32 h-10'}
     p-0`}
 >
   <span
     class={`absolute top-0 left-0 h-full w-1/2 rounded-full transition-transform duration-300
       ease-[cubic-bezier(0.4,0,0.2,1)]
-      ${
-        $appMode === 'fun'
-          ? 'translate-x-0 bg-gradient-to-r from-orange-400 to-amber-500'
-          : 'translate-x-full bg-gradient-to-r from-gray-300 to-gray-500'
-      }
+      ${$appMode === 'fun' ? 'translate-x-0' : 'translate-x-full'}
+      bg-[#f59e0b]
     `}
   />
   <button


### PR DESCRIPTION
## Summary
- update the mode toggle highlight to use the requested #f59e0b active color
- set the base toggle background to a light grey for the inactive side

## Testing
- npm run check *(fails: Could not find tsconfig/jsconfig file at ./tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c89b43e7088324aec0a74cdabc5b26