### PR TITLE
feat: show learn action for enrolled courses

### DIFF
--- a/src/lib/modules/learn/utils/session.js
+++ b/src/lib/modules/learn/utils/session.js
@@ -1,0 +1,58 @@
+import { browser } from '$app/environment';
+import { container } from '$lib/shared/di/container';
+import { setExamProfile } from '$lib/stores/examProfile';
+import { messages } from '$modules/chat/stores';
+
+const DEFAULT_MODE = 'practice';
+
+export function buildExamProfile(course, mode = DEFAULT_MODE) {
+  if (!course || !mode) {
+    return null;
+  }
+
+  const activeMode = mode === 'exam' ? course.exam : course.practice;
+
+  return {
+    courseId: course.id,
+    courseName: course.name,
+    description: course.description,
+    language: course.language,
+    level: course.level,
+    skills: course.skills ?? [],
+    mode,
+    practice: course.practice,
+    exam: course.exam,
+    activeMode,
+    settings: course.settings ?? null
+  };
+}
+
+export function resetLearningSession() {
+  if (!browser) {
+    return;
+  }
+
+  const previousSessionId = localStorage.getItem('sessionId');
+  localStorage.removeItem('sessionId');
+
+  if (previousSessionId && container.has('sessionFactory')) {
+    try {
+      const sessionFactory = container.resolve('sessionFactory');
+      sessionFactory.removeSession(previousSessionId);
+    } catch (error) {
+      console.warn('[Learning] Failed to clear previous session', error);
+    }
+  }
+
+  messages.set([]);
+}
+
+export function startLearningSession(course, mode = DEFAULT_MODE) {
+  const profile = buildExamProfile(course, mode);
+  if (!profile) {
+    return;
+  }
+
+  setExamProfile(profile);
+  resetLearningSession();
+}


### PR DESCRIPTION
## Summary
- update the shared course selection tiles to detect existing enrollments, show a Learn action, and customise the header for reuse
- extract learning session helpers so catalogue and my-courses can start courses without duplicating logic
- refresh the My Courses page to reuse the catalogue tiles and launch directly into a course when Learn is clicked

## Testing
- npm run check *(fails: missing ./tsconfig.json in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a280f39c8324a136563c678f137b