### PR TITLE
Fix course creation validation for agent metadata

### DIFF
--- a/src/lib/modules/courses/components/AgentManager.svelte
+++ b/src/lib/modules/courses/components/AgentManager.svelte
@@ -1,6 +1,7 @@
 <script>
   import { createEventDispatcher } from 'svelte';
   import Button from '$shared/components/Button.svelte';
+  import { AGENT_TYPES } from '$modules/courses/agents.js';
   import { Plus, Edit, Trash2, Save, X, Bot } from 'lucide-svelte';
 
   export let agents = [];
@@ -143,7 +144,10 @@
       description: agentForm.description.trim(),
       instructions: agentForm.instructions.trim(),
       systemPrompt: agentForm.systemPrompt.trim(),
-      type: 'standard',
+      type:
+        editingAgent?.type === AGENT_TYPES.ORCHESTRATION
+          ? AGENT_TYPES.ORCHESTRATION
+          : AGENT_TYPES.COURSE,
       ragEnabled: agentForm.ragEnabled,
       communicationStyle: { ...agentForm.communicationStyle },
       configuration: {},


### PR DESCRIPTION
## Summary
- normalize course agents and orchestration agent before validating so required identifiers and types are present
- reuse shared agent type constants when saving agents in the editor to avoid invalid "standard" types

## Testing
- npm run test
- npm run check *(fails: Could not find tsconfig/jsconfig file at ./tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d5af7469c88324888ea6f9688e040c