### PR TITLE
fix: show enrolled courses with go action

### DIFF
--- a/src/lib/modules/courses/stores/enrollmentStore.js
+++ b/src/lib/modules/courses/stores/enrollmentStore.js
@@ -28,7 +28,7 @@ function createEnrollmentStore() {
      * Initialize the store for a user
      */
     initialize: (userId) => {
-      if (!userId) {
+      if (userId === null || userId === undefined) {
         set({
           enrollments: [],
           loading: false,
@@ -174,7 +174,7 @@ function createEnrollmentStore() {
      * Refresh enrollments
      */
     refresh: (userId) => {
-      if (userId) {
+      if (userId !== null && userId !== undefined) {
         const enrollments = userEnrollmentService.getUserEnrollments(userId);
         update((state) => ({
           ...state,

--- a/src/lib/modules/learn/components/CourseSelection.svelte
+++ b/src/lib/modules/learn/components/CourseSelection.svelte
@@ -13,6 +13,10 @@
   export let allowCreateCourse = true;
   export let headerTitle = 'Course Catalog';
   export let headerSubtitle = 'Choose from available learning courses or create your own';
+  export let enrolledActionLabel = 'Learn';
+  export let joinActionLabel = 'Join';
+  export let enrolledActionAriaPrefix = 'Continue learning';
+  export let joinActionAriaPrefix = 'Join';
 
   const dispatch = createEventDispatcher();
 
@@ -386,11 +390,11 @@
             <Button
               class="w-full"
               on:click={() => handlePrimaryAction(course)}
-              aria-label={isCourseEnrolled(course)
-                ? `Continue learning ${course.name}`
-                : `Join ${course.name}`}
+              aria-label={`${
+                isCourseEnrolled(course) ? enrolledActionAriaPrefix : joinActionAriaPrefix
+              } ${course.name ?? 'course'}`}
             >
-              {isCourseEnrolled(course) ? 'Learn' : 'Join'}
+              {isCourseEnrolled(course) ? enrolledActionLabel : joinActionLabel}
             </Button>
           </div>
         </article>

--- a/src/routes/my-courses/+page.svelte
+++ b/src/routes/my-courses/+page.svelte
@@ -123,6 +123,8 @@
         allowCreateCourse={false}
         headerTitle="My Courses"
         headerSubtitle="Continue learning from the courses you've already enrolled in"
+        enrolledActionLabel="Go"
+        enrolledActionAriaPrefix="Go to"
         on:learn-course={handleLearnCourse}
       />
     {/if}


### PR DESCRIPTION
## Summary
- allow enrollment store initialization for zero-valued user ids so existing enrollments load correctly
- add configurable action labels to CourseSelection and use "Go" for enrolled courses in My Courses
- keep My Courses navigation opening the catalogue learning experience when resuming a course

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d84c71f6388324a201c27d4913878e