### PR TITLE
feat: add admin voice analytics dashboard

### DIFF
--- a/src/lib/modules/admin/voice-analytics/components/DiagnosticReportingPanel.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/DiagnosticReportingPanel.svelte
@@ -1,0 +1,220 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+
+  export let systemHealth = { issues: [], recommendations: [] };
+  export let performanceAnalysis = {};
+  export let uxSnapshot = {};
+  export let generatingReport = false;
+  export let lastGeneratedAt = null;
+  export let errorMessage = '';
+
+  const dispatch = createEventDispatcher();
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return 'Not generated yet';
+    try {
+      return new Date(timestamp).toLocaleString();
+    } catch (error) {
+      return 'Unknown';
+    }
+  };
+
+  const handleGenerate = () => {
+    dispatch('generate');
+  };
+
+  const handleCopyIssues = () => {
+    dispatch('copyIssues');
+  };
+
+  const handleExportDiagnostics = (format) => {
+    dispatch('exportDiagnostics', { format });
+  };
+
+  const handleExportReports = (format) => {
+    dispatch('export', { format });
+  };
+</script>
+
+<section
+  class="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-sm"
+>
+  <header
+    class="px-6 py-5 border-b border-stone-200 dark:border-gray-700 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
+  >
+    <div>
+      <h2 class="text-2xl font-semibold text-stone-900 dark:text-white">Diagnostic Reporting</h2>
+      <p class="text-sm text-stone-500 dark:text-gray-400">
+        Generate comprehensive reports and export raw diagnostic data for further analysis.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-3">
+      <button
+        class="inline-flex items-center justify-center rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-70"
+        on:click={handleGenerate}
+        disabled={generatingReport}
+      >
+        {generatingReport ? 'Generating report…' : 'Generate full diagnostic report'}
+      </button>
+      <button
+        class="inline-flex items-center justify-center rounded-lg border border-stone-200 dark:border-gray-700 px-4 py-2 text-sm font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+        on:click={handleCopyIssues}
+      >
+        Copy current issues
+      </button>
+    </div>
+  </header>
+
+  <div class="px-6 py-6 space-y-6">
+    <div class="flex flex-col gap-1 text-sm text-stone-500 dark:text-gray-400">
+      <span
+        >Last generated: <span class="font-medium text-stone-700 dark:text-gray-200"
+          >{formatTimestamp(lastGeneratedAt)}</span
+        ></span
+      >
+    </div>
+
+    {#if errorMessage}
+      <p
+        class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200"
+      >
+        {errorMessage}
+      </p>
+    {/if}
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Open issues
+        </h3>
+        {#if systemHealth?.issues?.length}
+          <ul class="mt-3 space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#each systemHealth.issues as issue}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 px-3 py-2"
+              >
+                {issue}
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="mt-3 text-sm text-stone-500 dark:text-gray-400">
+            No outstanding issues recorded.
+          </p>
+        {/if}
+      </div>
+
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Quick exports
+        </h3>
+        <div class="flex flex-wrap gap-3">
+          <button
+            class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-sm font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+            on:click={() => handleExportDiagnostics('json')}
+          >
+            Download diagnostics JSON
+          </button>
+          <button
+            class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-sm font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+            on:click={() => handleExportDiagnostics('csv')}
+          >
+            Download diagnostics CSV
+          </button>
+          <button
+            class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-sm font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+            on:click={() => handleExportReports('json')}
+          >
+            Export combined report JSON
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-3"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Performance summary
+        </h3>
+        {#if performanceAnalysis && Object.keys(performanceAnalysis).length > 0}
+          <ul class="space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#each Object.entries(performanceAnalysis) as [metricName, details]}
+              {#if typeof details === 'object' && details !== null && metricName !== 'trends'}
+                <li
+                  class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+                >
+                  <div class="font-semibold text-stone-700 dark:text-gray-200">
+                    {metricName.replace(/([A-Z])/g, ' $1').trim()}
+                  </div>
+                  <div class="text-xs text-stone-500 dark:text-gray-400">
+                    Avg: {details.average?.toFixed?.(1) ?? '—'} • Min: {details.min?.toFixed?.(1) ??
+                      '—'} • Max: {details.max?.toFixed?.(1) ?? '—'}
+                  </div>
+                </li>
+              {/if}
+            {/each}
+          </ul>
+        {:else}
+          <p class="text-sm text-stone-500 dark:text-gray-400">
+            Performance metrics will appear after monitoring collects data.
+          </p>
+        {/if}
+      </div>
+
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-3"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          UX highlights
+        </h3>
+        {#if uxSnapshot && Object.keys(uxSnapshot).length > 0}
+          <ul class="space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#if uxSnapshot?.metrics?.satisfaction}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                Satisfaction score: {(
+                  (uxSnapshot.metrics.satisfaction.overallScore ?? 0) * 100
+                ).toFixed(0)}%
+              </li>
+            {/if}
+            {#if uxSnapshot?.metrics?.interaction}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                Successful interactions: {uxSnapshot.metrics.interaction.successfulInteractions ??
+                  0} / {uxSnapshot.metrics.interaction.totalInteractions ?? 0}
+              </li>
+            {/if}
+            {#if uxSnapshot?.sessionHistory?.length}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                Sessions tracked: {uxSnapshot.sessionHistory.length}
+              </li>
+            {/if}
+            {#if uxSnapshot?.realTimeIndicators}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                Live satisfaction: {(
+                  (uxSnapshot.realTimeIndicators.currentSatisfaction ?? 0) * 100
+                ).toFixed(0)}%
+              </li>
+            {/if}
+          </ul>
+        {:else}
+          <p class="text-sm text-stone-500 dark:text-gray-400">
+            UX metrics will populate once tracking is active.
+          </p>
+        {/if}
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/lib/modules/admin/voice-analytics/components/HealthStatusPanel.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/HealthStatusPanel.svelte
@@ -1,0 +1,177 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import StatusBadge from './StatusBadge.svelte';
+
+  export let systemHealth = {
+    overall: 'unknown',
+    components: {},
+    issues: [],
+    recommendations: []
+  };
+  export let lastHealthCheck = null;
+  export let monitoringActive = false;
+  export let runningHealthCheck = false;
+  export let errorMessage = '';
+
+  const dispatch = createEventDispatcher();
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return 'Never';
+    try {
+      return new Date(timestamp).toLocaleString();
+    } catch (error) {
+      return 'Unknown';
+    }
+  };
+
+  $: components = Object.entries(systemHealth?.components ?? {});
+</script>
+
+<section
+  class="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-sm"
+>
+  <header
+    class="px-6 py-5 border-b border-stone-200 dark:border-gray-700 flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between"
+  >
+    <div>
+      <h2 class="text-2xl font-semibold text-stone-900 dark:text-white">
+        System Health Monitoring
+      </h2>
+      <p class="text-sm text-stone-500 dark:text-gray-400">
+        Real-time diagnostics across all voice components with actionable insights.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-3">
+      <StatusBadge
+        status={monitoringActive ? (systemHealth?.overall ?? 'unknown') : 'inactive'}
+        label={monitoringActive
+          ? 'Overall: ' + (systemHealth?.overall ?? 'Unknown')
+          : 'Monitoring paused'}
+      />
+      <button
+        class="inline-flex items-center justify-center rounded-lg border border-transparent bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-70"
+        on:click={() => dispatch('runHealthCheck')}
+        disabled={runningHealthCheck}
+      >
+        {runningHealthCheck ? 'Running health check…' : 'Run health check'}
+      </button>
+    </div>
+  </header>
+
+  <div class="px-6 py-5 space-y-6">
+    <div class="flex flex-col gap-2 text-sm text-stone-500 dark:text-gray-400">
+      <div>
+        Last health check: <span class="font-medium text-stone-700 dark:text-gray-200"
+          >{formatTimestamp(lastHealthCheck)}</span
+        >
+      </div>
+      <div>
+        Monitoring status: <span class="font-medium text-stone-700 dark:text-gray-200"
+          >{monitoringActive ? 'Active' : 'Paused'}</span
+        >
+      </div>
+    </div>
+
+    {#if errorMessage}
+      <p
+        class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200"
+      >
+        {errorMessage}
+      </p>
+    {/if}
+
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {#if components.length === 0}
+        <p class="text-sm text-stone-500 dark:text-gray-400 md:col-span-2 xl:col-span-3">
+          No component diagnostics available yet.
+        </p>
+      {:else}
+        {#each components as [component, details]}
+          <div
+            class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4 space-y-3"
+          >
+            <div class="flex items-center justify-between">
+              <h3
+                class="text-sm font-semibold uppercase tracking-wide text-stone-600 dark:text-gray-300"
+              >
+                {component.replace(/([A-Z])/g, ' $1').trim()}
+              </h3>
+              <StatusBadge status={details?.status ?? 'unknown'} />
+            </div>
+            {#if details?.issues?.length}
+              <ul class="space-y-1 text-sm text-stone-600 dark:text-gray-300">
+                {#each details.issues as issue}
+                  <li class="flex items-start gap-2">
+                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+                    <span>{issue}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="text-sm text-stone-500 dark:text-gray-400">No current issues detected.</p>
+            {/if}
+            {#if details?.metrics}
+              <dl class="grid grid-cols-2 gap-2 text-xs text-stone-500 dark:text-gray-400">
+                {#each Object.entries(details.metrics) as [metricName, metricValue]}
+                  <div class="rounded-md bg-white dark:bg-gray-800/60 px-2 py-1">
+                    <dt class="font-medium text-stone-600 dark:text-gray-300">
+                      {metricName.replace(/([A-Z])/g, ' $1').trim()}
+                    </dt>
+                    <dd class="font-semibold text-stone-800 dark:text-white">
+                      {typeof metricValue === 'number' ? metricValue.toFixed(2) : metricValue}
+                    </dd>
+                  </div>
+                {/each}
+              </dl>
+            {/if}
+          </div>
+        {/each}
+      {/if}
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <div>
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Issues
+        </h3>
+        {#if systemHealth?.issues?.length}
+          <ul class="mt-3 space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#each systemHealth.issues as issue}
+              <li
+                class="flex items-start gap-2 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-3 py-2"
+              >
+                <span class="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-red-500"></span>
+                <span>{issue}</span>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="mt-3 text-sm text-stone-500 dark:text-gray-400">
+            No outstanding issues detected.
+          </p>
+        {/if}
+      </div>
+
+      <div>
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Recommendations
+        </h3>
+        {#if systemHealth?.recommendations?.length}
+          <ul class="mt-3 space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#each systemHealth.recommendations as recommendation}
+              <li
+                class="rounded-lg border border-emerald-200 dark:border-emerald-900/60 bg-emerald-50 dark:bg-emerald-900/20 px-3 py-2"
+              >
+                {recommendation}
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="mt-3 text-sm text-stone-500 dark:text-gray-400">
+            Diagnostics look good—no immediate actions required.
+          </p>
+        {/if}
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/lib/modules/admin/voice-analytics/components/MetricSparkline.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/MetricSparkline.svelte
@@ -1,0 +1,97 @@
+<script>
+  export let points = [];
+  export let stroke = 'currentColor';
+  export let label = '';
+  export let value = null;
+  export let valueFormatter = (val) => (typeof val === 'number' ? val.toFixed(0) : val);
+
+  const width = 160;
+  const height = 56;
+  const padding = 6;
+
+  const componentId = `spark-${Math.random().toString(36).slice(2)}`;
+
+  const sanitizePoints = (input) =>
+    (input ?? []).filter(
+      (point) => point && typeof point.value === 'number' && Number.isFinite(point.value)
+    );
+
+  $: sanitized = sanitizePoints(points);
+  $: values = sanitized.map((point) => point.value);
+  $: min = values.length > 0 ? Math.min(...values) : 0;
+  $: max = values.length > 0 ? Math.max(...values) : 0;
+  $: range = max - min || 1;
+  $: pathD =
+    sanitized.length > 1
+      ? sanitized
+          .map((point, index) => {
+            const x = (index / (sanitized.length - 1)) * (width - padding * 2) + padding;
+            const normalized = (point.value - min) / range;
+            const y = height - padding - normalized * (height - padding * 2);
+            return `${index === 0 ? 'M' : 'L'}${x},${y}`;
+          })
+          .join(' ')
+      : '';
+  $: areaD =
+    sanitized.length > 1
+      ? `${pathD} L${width - padding},${height - padding} L${padding},${height - padding} Z`
+      : '';
+  $: latestValue = sanitized.length ? sanitized[sanitized.length - 1].value : value;
+</script>
+
+<div class="space-y-2">
+  {#if label}
+    <div class="flex items-center justify-between">
+      <p class="text-sm font-medium text-stone-600 dark:text-gray-300">{label}</p>
+      {#if latestValue !== undefined && latestValue !== null}
+        <span class="text-sm font-semibold text-stone-900 dark:text-white">
+          {valueFormatter(latestValue)}
+        </span>
+      {/if}
+    </div>
+  {/if}
+  <svg
+    viewBox={`0 0 ${width} ${height}`}
+    class="w-full h-16"
+    role="img"
+    aria-label={label ? `${label} trend sparkline` : 'Metric trend sparkline'}
+  >
+    <defs>
+      <linearGradient id={`${componentId}-gradient`} x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.25" />
+        <stop offset="100%" stop-color="#f59e0b" stop-opacity="0" />
+      </linearGradient>
+    </defs>
+    <rect
+      x="0"
+      y="0"
+      {width}
+      {height}
+      fill={`url(#${componentId}-gradient)`}
+      opacity={sanitized.length > 1 ? 1 : 0}
+      class="transition-opacity duration-200"
+    />
+    {#if sanitized.length > 1}
+      <path d={areaD} fill={`url(#${componentId}-gradient)`} class="opacity-70" />
+      <path
+        d={pathD}
+        fill="none"
+        {stroke}
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    {:else}
+      <line
+        x1={padding}
+        y1={height / 2}
+        x2={width - padding}
+        y2={height / 2}
+        {stroke}
+        stroke-width="2"
+        stroke-linecap="round"
+        class="opacity-50"
+      />
+    {/if}
+  </svg>
+</div>

--- a/src/lib/modules/admin/voice-analytics/components/PerformanceAnalyticsPanel.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/PerformanceAnalyticsPanel.svelte
@@ -1,0 +1,321 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import MetricSparkline from './MetricSparkline.svelte';
+  import StatusBadge from './StatusBadge.svelte';
+
+  export let performance = {
+    realTimeMetrics: null,
+    trends: {},
+    alerts: [],
+    thresholds: {},
+    analysis: {}
+  };
+  export let monitoringActive = false;
+  export let lastUpdated = null;
+  export let errorMessage = '';
+
+  const dispatch = createEventDispatcher();
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return 'Not updated yet';
+    try {
+      return new Date(timestamp).toLocaleTimeString();
+    } catch (error) {
+      return 'Unknown';
+    }
+  };
+
+  const formatMilliseconds = (value) =>
+    typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(0)} ms` : '—';
+
+  const formatMemory = (bytes) => {
+    if (typeof bytes !== 'number' || !Number.isFinite(bytes)) return '—';
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  };
+
+  let thresholdsSignature = '';
+  let editingThresholds = {
+    latency: 100,
+    memory: 50,
+    response: 2000
+  };
+
+  $: {
+    const signature = JSON.stringify(performance?.thresholds ?? {});
+    if (signature !== thresholdsSignature) {
+      thresholdsSignature = signature;
+      editingThresholds = {
+        latency: Math.round(performance?.thresholds?.audioProcessing?.latency ?? 100),
+        memory: Math.round(
+          (performance?.thresholds?.audioProcessing?.memoryUsage ?? 50 * 1024 * 1024) /
+            (1024 * 1024)
+        ),
+        response: Math.round(performance?.thresholds?.speechSynthesis?.responseTime ?? 2000)
+      };
+    }
+  }
+
+  const applyThresholds = () => {
+    dispatch('updateThresholds', {
+      thresholds: {
+        audioProcessing: {
+          latency: editingThresholds.latency,
+          memoryUsage: editingThresholds.memory * 1024 * 1024
+        },
+        speechSynthesis: {
+          responseTime: editingThresholds.response
+        }
+      }
+    });
+  };
+
+  const exportData = (format) => {
+    dispatch('export', { format });
+  };
+
+  $: realTimeMetrics = performance?.realTimeMetrics ?? {};
+  $: trends = performance?.trends ?? {};
+  $: alerts = performance?.alerts ?? [];
+  $: analysis = performance?.analysis ?? {};
+</script>
+
+<section
+  class="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-sm"
+>
+  <header
+    class="px-6 py-5 border-b border-stone-200 dark:border-gray-700 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
+  >
+    <div>
+      <h2 class="text-2xl font-semibold text-stone-900 dark:text-white">Performance Analytics</h2>
+      <p class="text-sm text-stone-500 dark:text-gray-400">
+        Latency, memory usage, and alert tracking for every voice subsystem.
+      </p>
+    </div>
+    <div class="flex items-center gap-3 flex-wrap">
+      <StatusBadge
+        status={monitoringActive ? 'healthy' : 'inactive'}
+        label={monitoringActive ? 'Monitoring active' : 'Monitoring paused'}
+      />
+      <div class="text-xs text-stone-500 dark:text-gray-400">
+        Last update: {formatTimestamp(lastUpdated)}
+      </div>
+      <div class="flex items-center gap-2">
+        <button
+          class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-xs font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+          on:click={() => exportData('json')}
+        >
+          Export JSON
+        </button>
+        <button
+          class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-xs font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+          on:click={() => exportData('csv')}
+        >
+          Export CSV
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <div class="px-6 py-6 space-y-6">
+    {#if errorMessage}
+      <p
+        class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200"
+      >
+        {errorMessage}
+      </p>
+    {/if}
+
+    <div class="grid gap-4 md:grid-cols-3">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <MetricSparkline
+          label="Audio latency"
+          points={trends.audioLatency}
+          stroke="#f59e0b"
+          valueFormatter={(value) => `${value.toFixed(0)} ms`}
+        />
+        <p class="mt-3 text-xs text-stone-500 dark:text-gray-400">
+          Current: {formatMilliseconds(realTimeMetrics?.audioProcessing?.currentLatency)}
+        </p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <MetricSparkline
+          label="Speech synthesis time"
+          points={trends.synthesisTime}
+          stroke="#6366f1"
+          valueFormatter={(value) => `${value.toFixed(0)} ms`}
+        />
+        <p class="mt-3 text-xs text-stone-500 dark:text-gray-400">
+          Current: {formatMilliseconds(realTimeMetrics?.speechSynthesis?.currentResponseTime)}
+        </p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <MetricSparkline
+          label="Memory usage"
+          points={trends.memoryUsage}
+          stroke="#10b981"
+          valueFormatter={(value) => `${(value / 1024 / 1024).toFixed(1)} MB`}
+        />
+        <p class="mt-3 text-xs text-stone-500 dark:text-gray-400">
+          Current: {formatMemory(realTimeMetrics?.audioProcessing?.memoryUsage)}
+        </p>
+      </div>
+    </div>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Thresholds
+        </h3>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <label class="space-y-1 text-sm text-stone-600 dark:text-gray-300">
+            <span class="font-medium">Max latency (ms)</span>
+            <input
+              type="number"
+              min="1"
+              bind:value={editingThresholds.latency}
+              class="w-full rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-stone-800 dark:text-white focus:border-amber-500 focus:ring-amber-500"
+            />
+          </label>
+          <label class="space-y-1 text-sm text-stone-600 dark:text-gray-300">
+            <span class="font-medium">Max memory (MB)</span>
+            <input
+              type="number"
+              min="1"
+              bind:value={editingThresholds.memory}
+              class="w-full rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-stone-800 dark:text-white focus:border-amber-500 focus:ring-amber-500"
+            />
+          </label>
+          <label class="space-y-1 text-sm text-stone-600 dark:text-gray-300 sm:col-span-2">
+            <span class="font-medium">Max speech response (ms)</span>
+            <input
+              type="number"
+              min="1"
+              bind:value={editingThresholds.response}
+              class="w-full rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-stone-800 dark:text-white focus:border-amber-500 focus:ring-amber-500"
+            />
+          </label>
+        </div>
+        <button
+          class="inline-flex items-center justify-center rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-600"
+          on:click={applyThresholds}
+        >
+          Apply thresholds
+        </button>
+      </div>
+
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Recent alerts
+        </h3>
+        {#if alerts.length === 0}
+          <p class="text-sm text-stone-500 dark:text-gray-400">
+            No alerts triggered in the latest sampling window.
+          </p>
+        {:else}
+          <ul class="space-y-3 text-sm">
+            {#each alerts as alert (alert.id)}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                <div class="flex items-center justify-between">
+                  <span class="font-semibold text-stone-700 dark:text-gray-200"
+                    >{alert.message}</span
+                  >
+                  <StatusBadge
+                    status={alert.severity ?? 'warning'}
+                    label={alert.severity ?? 'Warning'}
+                  />
+                </div>
+                <div class="mt-2 flex flex-wrap gap-3 text-xs text-stone-500 dark:text-gray-400">
+                  <span
+                    >{alert.timestamp ? new Date(alert.timestamp).toLocaleTimeString() : '—'}</span
+                  >
+                  {#if alert.threshold !== undefined && alert.value !== undefined}
+                    <span
+                      >Value: {typeof alert.value === 'number'
+                        ? alert.value.toFixed(1)
+                        : alert.value}</span
+                    >
+                    <span>Threshold: {alert.threshold}</span>
+                  {/if}
+                </div>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    </div>
+
+    {#if analysis?.trends}
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Trend summary
+        </h3>
+        <div class="text-sm text-stone-600 dark:text-gray-300">
+          <p>
+            Overall trend:
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{analysis.trends.overall ?? 'stable'}</span
+            >
+          </p>
+        </div>
+        <div class="grid gap-4 md:grid-cols-2 text-sm text-stone-600 dark:text-gray-300">
+          <div>
+            <h4 class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+              Areas of concern
+            </h4>
+            {#if analysis.trends.concerns?.length}
+              <ul class="mt-2 space-y-2">
+                {#each analysis.trends.concerns as concern}
+                  <li
+                    class="flex items-start gap-2 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 px-3 py-2"
+                  >
+                    <span class="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-red-500"></span>
+                    <span>{concern}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="mt-2 text-xs text-stone-500 dark:text-gray-400">
+                No degrading trends detected.
+              </p>
+            {/if}
+          </div>
+          <div>
+            <h4 class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+              Improvements
+            </h4>
+            {#if analysis.trends.improvements?.length}
+              <ul class="mt-2 space-y-2">
+                {#each analysis.trends.improvements as improvement}
+                  <li
+                    class="flex items-start gap-2 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 px-3 py-2"
+                  >
+                    <span class="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-500"></span>
+                    <span>{improvement}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="mt-2 text-xs text-stone-500 dark:text-gray-400">
+                No major improvements recorded yet.
+              </p>
+            {/if}
+          </div>
+        </div>
+      </div>
+    {/if}
+  </div>
+</section>

--- a/src/lib/modules/admin/voice-analytics/components/StatusBadge.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/StatusBadge.svelte
@@ -1,0 +1,46 @@
+<script>
+  export let status = 'unknown';
+  export let label = '';
+
+  const STATUS_STYLES = {
+    healthy: {
+      badge: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+      dot: 'bg-emerald-500'
+    },
+    degraded: {
+      badge: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+      dot: 'bg-amber-500'
+    },
+    warning: {
+      badge: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+      dot: 'bg-amber-500'
+    },
+    critical: {
+      badge: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+      dot: 'bg-red-500'
+    },
+    error: {
+      badge: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+      dot: 'bg-red-500'
+    },
+    inactive: {
+      badge: 'bg-slate-100 text-slate-700 dark:bg-slate-800/60 dark:text-slate-200',
+      dot: 'bg-slate-400'
+    },
+    unknown: {
+      badge: 'bg-slate-100 text-slate-700 dark:bg-slate-800/60 dark:text-slate-200',
+      dot: 'bg-slate-400'
+    }
+  };
+
+  $: normalizedStatus = (status || 'unknown').toString().toLowerCase();
+  $: style = STATUS_STYLES[normalizedStatus] ?? STATUS_STYLES.unknown;
+  $: computedLabel = label || normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
+</script>
+
+<span
+  class={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium gap-2 ${style.badge}`}
+>
+  <span class={`w-2 h-2 rounded-full ${style.dot}`} aria-hidden="true"></span>
+  <span>{computedLabel}</span>
+</span>

--- a/src/lib/modules/admin/voice-analytics/components/UXMetricsPanel.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/UXMetricsPanel.svelte
@@ -1,0 +1,294 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import StatusBadge from './StatusBadge.svelte';
+
+  export let ux = {
+    metrics: {},
+    realTimeIndicators: {},
+    sessionHistory: [],
+    currentSession: null,
+    trackingEnabled: false
+  };
+  export let lastUpdated = null;
+  export let errorMessage = '';
+
+  const dispatch = createEventDispatcher();
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return '—';
+    try {
+      return new Date(timestamp).toLocaleString();
+    } catch (error) {
+      return '—';
+    }
+  };
+
+  const formatDuration = (duration) => {
+    if (typeof duration !== 'number' || !Number.isFinite(duration) || duration <= 0) return '0m';
+    const minutes = duration / 60000;
+    if (minutes < 1) {
+      return `${(duration / 1000).toFixed(0)}s`;
+    }
+    return `${minutes.toFixed(1)}m`;
+  };
+
+  const safeRate = (success, total) => {
+    if (typeof success !== 'number' || typeof total !== 'number' || total <= 0) return 0;
+    return Math.min(1, Math.max(0, success / total));
+  };
+
+  const percentage = (value, decimals = 0) => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return '0%';
+    return `${(value * 100).toFixed(decimals)}%`;
+  };
+
+  const toggleTracking = (event) => {
+    dispatch('toggleTracking', { enabled: event.currentTarget.checked });
+  };
+
+  const exportData = (format) => {
+    dispatch('export', { format });
+  };
+
+  $: metrics = ux?.metrics ?? {};
+  $: indicators = ux?.realTimeIndicators ?? {};
+  $: sessionHistory = ux?.sessionHistory ?? [];
+  $: trackingEnabled = ux?.trackingEnabled ?? false;
+  $: currentSession = ux?.currentSession ?? null;
+
+  $: successRate = safeRate(
+    metrics?.interaction?.successfulInteractions,
+    metrics?.interaction?.totalInteractions
+  );
+  $: satisfactionScore =
+    metrics?.satisfaction?.overallScore ?? indicators?.currentSatisfaction ?? 0;
+  $: averageSessionDuration = metrics?.engagement?.sessionDuration ?? currentSession?.duration ?? 0;
+  $: returnRate = metrics?.engagement?.returnUserRate ?? 0;
+</script>
+
+<section
+  class="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-sm"
+>
+  <header
+    class="px-6 py-5 border-b border-stone-200 dark:border-gray-700 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
+  >
+    <div>
+      <h2 class="text-2xl font-semibold text-stone-900 dark:text-white">
+        User Experience Tracking
+      </h2>
+      <p class="text-sm text-stone-500 dark:text-gray-400">
+        Monitor interaction quality, satisfaction signals, and recent session history.
+      </p>
+    </div>
+    <div class="flex items-center gap-4 flex-wrap">
+      <label
+        class="inline-flex items-center gap-2 text-sm font-medium text-stone-600 dark:text-gray-300"
+      >
+        <input
+          type="checkbox"
+          checked={trackingEnabled}
+          on:change={toggleTracking}
+          class="h-4 w-4 rounded border-stone-300 text-amber-500 focus:ring-amber-500"
+        />
+        Live UX tracking
+      </label>
+      <StatusBadge
+        status={trackingEnabled ? 'healthy' : 'inactive'}
+        label={trackingEnabled ? 'Tracking active' : 'Tracking paused'}
+      />
+      <div class="flex items-center gap-2 text-xs text-stone-500 dark:text-gray-400">
+        <span>Last update: {formatTimestamp(lastUpdated)}</span>
+        <button
+          class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-xs font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+          on:click={() => exportData('json')}
+        >
+          Export JSON
+        </button>
+        <button
+          class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-xs font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+          on:click={() => exportData('csv')}
+        >
+          Export CSV
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <div class="px-6 py-6 space-y-6">
+    {#if errorMessage}
+      <p
+        class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200"
+      >
+        {errorMessage}
+      </p>
+    {/if}
+
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <p class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+          Success rate
+        </p>
+        <p class="mt-2 text-2xl font-semibold text-stone-900 dark:text-white">
+          {percentage(successRate, 0)}
+        </p>
+        <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">
+          {metrics?.interaction?.successfulInteractions ?? 0} successful interactions out of {metrics
+            ?.interaction?.totalInteractions ?? 0}
+        </p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <p class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+          Avg session duration
+        </p>
+        <p class="mt-2 text-2xl font-semibold text-stone-900 dark:text-white">
+          {formatDuration(averageSessionDuration)}
+        </p>
+        <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">Measured from recent sessions.</p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <p class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+          Satisfaction
+        </p>
+        <p class="mt-2 text-2xl font-semibold text-stone-900 dark:text-white">
+          {percentage(satisfactionScore, 0)}
+        </p>
+        <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">
+          Real-time satisfaction sentiment.
+        </p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <p class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">Engagement</p>
+        <p class="mt-2 text-2xl font-semibold text-stone-900 dark:text-white">
+          {percentage(returnRate, 0)}
+        </p>
+        <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">
+          Return user rate & ongoing engagement.
+        </p>
+      </div>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Current session snapshot
+        </h3>
+        {#if trackingEnabled && currentSession}
+          <dl class="grid gap-3 text-sm text-stone-600 dark:text-gray-300">
+            <div>
+              <dt class="font-semibold text-stone-700 dark:text-gray-200">Session ID</dt>
+              <dd class="mt-1 break-all">{currentSession.id}</dd>
+            </div>
+            <div>
+              <dt class="font-semibold text-stone-700 dark:text-gray-200">Started</dt>
+              <dd class="mt-1">{formatTimestamp(currentSession.startTime)}</dd>
+            </div>
+            <div>
+              <dt class="font-semibold text-stone-700 dark:text-gray-200">Duration</dt>
+              <dd class="mt-1">
+                {formatDuration(
+                  currentSession.startTime ? Math.max(0, Date.now() - currentSession.startTime) : 0
+                )}
+              </dd>
+            </div>
+          </dl>
+        {:else}
+          <p class="text-sm text-stone-500 dark:text-gray-400">
+            {trackingEnabled
+              ? 'Waiting for live interactions…'
+              : 'Enable tracking to capture live sessions.'}
+          </p>
+        {/if}
+
+        <div
+          class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-3 text-sm text-stone-600 dark:text-gray-300 space-y-1"
+        >
+          <div class="flex items-center justify-between">
+            <span>Engagement level</span>
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{indicators?.engagementLevel ?? '—'}</span
+            >
+          </div>
+          <div class="flex items-center justify-between">
+            <span>Frustration</span>
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{indicators?.userFrustration ?? '—'}</span
+            >
+          </div>
+          <div class="flex items-center justify-between">
+            <span>Cognitive load</span>
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{indicators?.cognitiveLoad ?? '—'}</span
+            >
+          </div>
+          <div class="flex items-center justify-between">
+            <span>Real-time satisfaction</span>
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{percentage(indicators?.currentSatisfaction ?? 0, 0)}</span
+            >
+          </div>
+        </div>
+      </div>
+
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4"
+      >
+        <h3
+          class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide mb-3"
+        >
+          Recent sessions
+        </h3>
+        {#if sessionHistory.length === 0}
+          <p class="text-sm text-stone-500 dark:text-gray-400">No session history captured yet.</p>
+        {:else}
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-stone-200 dark:divide-gray-700 text-sm">
+              <thead
+                class="bg-stone-50 dark:bg-gray-900/40 text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400"
+              >
+                <tr>
+                  <th class="px-3 py-2 text-left font-semibold">Session</th>
+                  <th class="px-3 py-2 text-left font-semibold">Duration</th>
+                  <th class="px-3 py-2 text-left font-semibold">Success</th>
+                  <th class="px-3 py-2 text-left font-semibold">Errors</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-stone-200 dark:divide-gray-700">
+                {#each sessionHistory as session (session.id)}
+                  <tr class="bg-white dark:bg-gray-900/20">
+                    <td class="px-3 py-2 align-top">
+                      <div class="font-semibold text-stone-700 dark:text-gray-200">
+                        {session.id}
+                      </div>
+                      <div class="text-xs text-stone-500 dark:text-gray-400">
+                        {formatTimestamp(session.startTime)}
+                      </div>
+                    </td>
+                    <td class="px-3 py-2 align-top text-stone-600 dark:text-gray-300"
+                      >{formatDuration(session.duration)}</td
+                    >
+                    <td class="px-3 py-2 align-top text-stone-600 dark:text-gray-300">
+                      {percentage(session?.metrics?.efficiency?.interactionSuccessRate ?? 0, 0)}
+                    </td>
+                    <td class="px-3 py-2 align-top text-stone-600 dark:text-gray-300"
+                      >{session?.metrics?.errors?.totalErrors ?? 0}</td
+                    >
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/lib/modules/admin/voice-analytics/voiceAnalyticsStore.js
+++ b/src/lib/modules/admin/voice-analytics/voiceAnalyticsStore.js
@@ -1,0 +1,526 @@
+import { writable, get } from 'svelte/store';
+import { browser } from '$app/environment';
+import { voiceDiagnostics } from '$modules/chat/VoiceDiagnostics.js';
+import { voicePerformanceMonitor } from '$modules/chat/VoicePerformanceMonitor.js';
+import { voiceUXMetricsTracker } from '$modules/chat/VoiceUXMetricsTracker.js';
+
+const MAX_TREND_POINTS = 15;
+
+const trimSeries = (series = []) => {
+  if (!Array.isArray(series)) {
+    return [];
+  }
+  return series.slice(-MAX_TREND_POINTS);
+};
+
+const createInitialState = () => ({
+  systemHealth: {
+    overall: 'unknown',
+    components: {},
+    issues: [],
+    recommendations: [],
+    lastHealthCheck: null
+  },
+  performance: {
+    realTimeMetrics: null,
+    trends: {
+      audioLatency: [],
+      synthesisTime: [],
+      memoryUsage: [],
+      userInteractions: [],
+      errorRates: []
+    },
+    analysis: {},
+    alerts: [],
+    thresholds: voicePerformanceMonitor.thresholds
+  },
+  ux: {
+    metrics: voiceUXMetricsTracker.uxMetrics,
+    realTimeIndicators: voiceUXMetricsTracker.realTimeIndicators,
+    sessionHistory: [],
+    currentSession: null,
+    trackingEnabled: voiceUXMetricsTracker.isTracking
+  },
+  lastUpdated: null,
+  monitoring: {
+    diagnostics: voiceDiagnostics.isMonitoring,
+    performance: voicePerformanceMonitor.isActive,
+    uxTracking: voiceUXMetricsTracker.isTracking
+  },
+  errors: {},
+  ui: {
+    healthCheckRunning: false,
+    generatingReport: false
+  }
+});
+
+const createVoiceAnalyticsStore = () => {
+  const { subscribe, set, update } = writable(createInitialState());
+
+  let initialized = false;
+  let healthPoll = null;
+  let performancePoll = null;
+  let uxPoll = null;
+
+  let diagnosticsStartedByStore = false;
+  let performanceStartedByStore = false;
+  let uxStartedByStore = false;
+
+  const syncDiagnostics = () => {
+    if (!browser) return;
+
+    try {
+      const status = voiceDiagnostics.getCurrentStatus();
+
+      update((state) => ({
+        ...state,
+        systemHealth: {
+          ...state.systemHealth,
+          ...(status.systemHealth ?? {}),
+          lastHealthCheck: status.lastHealthCheck ?? state.systemHealth.lastHealthCheck
+        },
+        performance: {
+          ...state.performance,
+          analysis: status.performanceMetrics ?? state.performance.analysis,
+          thresholds: voicePerformanceMonitor.thresholds
+        },
+        monitoring: {
+          ...state.monitoring,
+          diagnostics: status.isMonitoring ?? voiceDiagnostics.isMonitoring,
+          performance: voicePerformanceMonitor.isActive,
+          uxTracking: voiceUXMetricsTracker.isTracking
+        },
+        errors: { ...state.errors, diagnostics: null },
+        lastUpdated: Date.now()
+      }));
+    } catch (error) {
+      console.error('Failed to sync diagnostics status', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Unable to retrieve system health data.'
+        }
+      }));
+    }
+  };
+
+  const syncPerformance = () => {
+    if (!browser) return;
+
+    try {
+      const metrics = voicePerformanceMonitor.getCurrentMetrics();
+      const buffer = metrics.performanceBuffer ?? {};
+
+      update((state) => ({
+        ...state,
+        performance: {
+          ...state.performance,
+          realTimeMetrics: metrics.realTimeMetrics ?? state.performance.realTimeMetrics,
+          trends: {
+            audioLatency: trimSeries(buffer.audioLatency),
+            synthesisTime: trimSeries(buffer.synthesisTime),
+            memoryUsage: trimSeries(buffer.memoryUsage),
+            userInteractions: trimSeries(buffer.userInteractions),
+            errorRates: trimSeries(buffer.errorRates)
+          },
+          alerts: metrics.alertHistory ?? state.performance.alerts,
+          thresholds: metrics.thresholds ?? voicePerformanceMonitor.thresholds,
+          analysis: state.performance.analysis
+        },
+        monitoring: {
+          ...state.monitoring,
+          performance: metrics.isActive ?? voicePerformanceMonitor.isActive
+        },
+        errors: { ...state.errors, performance: null },
+        lastUpdated: Date.now()
+      }));
+    } catch (error) {
+      console.error('Failed to sync performance metrics', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          performance: 'Unable to update performance metrics.'
+        }
+      }));
+    }
+  };
+
+  const syncUX = () => {
+    if (!browser) return;
+
+    try {
+      const snapshot = voiceUXMetricsTracker.getCurrentMetrics();
+      update((state) => ({
+        ...state,
+        ux: {
+          metrics: snapshot.uxMetrics ?? state.ux.metrics,
+          realTimeIndicators: snapshot.realTimeIndicators ?? state.ux.realTimeIndicators,
+          sessionHistory: snapshot.sessionHistory ?? state.ux.sessionHistory,
+          currentSession: snapshot.currentSession ?? state.ux.currentSession,
+          trackingEnabled: snapshot.isTracking ?? voiceUXMetricsTracker.isTracking
+        },
+        monitoring: {
+          ...state.monitoring,
+          uxTracking: snapshot.isTracking ?? voiceUXMetricsTracker.isTracking
+        },
+        errors: { ...state.errors, ux: null },
+        lastUpdated: Date.now()
+      }));
+    } catch (error) {
+      console.error('Failed to sync UX metrics', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          ux: 'Unable to update UX tracking metrics.'
+        }
+      }));
+    }
+  };
+
+  const startUxPolling = () => {
+    if (uxPoll || !browser) return;
+
+    uxPoll = setInterval(() => {
+      syncUX();
+    }, 5000);
+  };
+
+  const stopUxPolling = () => {
+    if (uxPoll) {
+      clearInterval(uxPoll);
+      uxPoll = null;
+    }
+  };
+
+  const init = () => {
+    if (!browser || initialized) {
+      return;
+    }
+
+    initialized = true;
+
+    set(createInitialState());
+
+    try {
+      if (!voiceDiagnostics.isMonitoring) {
+        voiceDiagnostics.startMonitoring({ enableRealTimeAlerts: true });
+        diagnosticsStartedByStore = true;
+      }
+    } catch (error) {
+      console.error('Failed to start diagnostics monitoring', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Diagnostics monitoring could not be started.'
+        }
+      }));
+    }
+
+    try {
+      if (!voicePerformanceMonitor.isActive) {
+        voicePerformanceMonitor.startMonitoring({ enableAlerts: true });
+        performanceStartedByStore = true;
+      }
+    } catch (error) {
+      console.error('Failed to start performance monitoring', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          performance: 'Performance monitoring could not be started.'
+        }
+      }));
+    }
+
+    syncDiagnostics();
+    syncPerformance();
+    syncUX();
+
+    voiceDiagnostics
+      .performHealthCheck()
+      .then((result) => {
+        update((state) => ({
+          ...state,
+          systemHealth: {
+            ...state.systemHealth,
+            ...(result ?? {}),
+            lastHealthCheck: result?.timestamp ?? Date.now()
+          },
+          errors: { ...state.errors, diagnostics: null },
+          lastUpdated: Date.now()
+        }));
+      })
+      .catch((error) => {
+        console.error('Initial health check failed', error);
+        update((state) => ({
+          ...state,
+          errors: {
+            ...state.errors,
+            diagnostics: 'Initial health check failed. Try running it again.'
+          }
+        }));
+      });
+
+    healthPoll = setInterval(() => {
+      syncDiagnostics();
+    }, 30000);
+
+    performancePoll = setInterval(() => {
+      syncPerformance();
+    }, 2000);
+
+    if (voiceUXMetricsTracker.isTracking) {
+      startUxPolling();
+    }
+  };
+
+  const runHealthCheck = async () => {
+    if (!browser) return null;
+
+    update((state) => ({
+      ...state,
+      ui: { ...state.ui, healthCheckRunning: true }
+    }));
+
+    try {
+      const result = await voiceDiagnostics.performHealthCheck();
+      update((state) => ({
+        ...state,
+        systemHealth: {
+          ...state.systemHealth,
+          ...(result ?? {}),
+          lastHealthCheck: result?.timestamp ?? Date.now()
+        },
+        errors: { ...state.errors, diagnostics: null },
+        ui: { ...state.ui, healthCheckRunning: false },
+        lastUpdated: Date.now()
+      }));
+      return result;
+    } catch (error) {
+      console.error('Manual health check failed', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Health check failed. Please try again.'
+        },
+        ui: { ...state.ui, healthCheckRunning: false }
+      }));
+      throw error;
+    }
+  };
+
+  const toggleUXTracking = async (enable) => {
+    if (!browser) return false;
+
+    try {
+      if (enable) {
+        voiceUXMetricsTracker.startTracking();
+        uxStartedByStore = true;
+        syncUX();
+        startUxPolling();
+        return true;
+      } else {
+        if (voiceUXMetricsTracker.isTracking) {
+          voiceUXMetricsTracker.stopTracking();
+        }
+        voiceUXMetricsTracker.resetMetrics();
+        syncUX();
+        stopUxPolling();
+        uxStartedByStore = false;
+        return true;
+      }
+    } catch (error) {
+      console.error('Failed to toggle UX tracking', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          ux: enable
+            ? 'Unable to start UX tracking. Check browser permissions.'
+            : 'Unable to stop UX tracking cleanly.'
+        }
+      }));
+      return false;
+    }
+  };
+
+  const updateThresholds = (thresholds) => {
+    if (!browser || !thresholds) return false;
+
+    try {
+      voicePerformanceMonitor.updateThresholds(thresholds);
+      syncPerformance();
+      return true;
+    } catch (error) {
+      console.error('Failed to update performance thresholds', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          performance: 'Could not update performance thresholds.'
+        }
+      }));
+      return false;
+    }
+  };
+
+  const generateCombinedReport = async () => {
+    if (!browser) return null;
+
+    update((state) => ({
+      ...state,
+      ui: { ...state.ui, generatingReport: true }
+    }));
+
+    try {
+      const report = await voiceDiagnostics.generateDiagnosticReport({
+        includeHealthCheck: true,
+        includePerformanceMetrics: true,
+        includeUXMetrics: true,
+        includeRecommendations: true
+      });
+
+      const performanceSnapshot = voicePerformanceMonitor.getCurrentMetrics();
+      const uxSnapshot = voiceUXMetricsTracker.getCurrentMetrics();
+
+      const combinedReport = {
+        ...report,
+        performanceSnapshot,
+        uxSnapshot
+      };
+
+      update((state) => ({
+        ...state,
+        ui: { ...state.ui, generatingReport: false }
+      }));
+
+      return combinedReport;
+    } catch (error) {
+      console.error('Failed to generate diagnostic report', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Unable to generate diagnostic report.'
+        },
+        ui: { ...state.ui, generatingReport: false }
+      }));
+      throw error;
+    }
+  };
+
+  const exportPerformanceData = (options) => {
+    if (!browser) return null;
+
+    try {
+      return voicePerformanceMonitor.exportPerformanceData(options);
+    } catch (error) {
+      console.error('Failed to export performance data', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          performance: 'Performance data export failed.'
+        }
+      }));
+      return null;
+    }
+  };
+
+  const exportUXData = (options) => {
+    if (!browser) return null;
+
+    try {
+      return voiceUXMetricsTracker.exportUXData(options);
+    } catch (error) {
+      console.error('Failed to export UX data', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          ux: 'UX data export failed.'
+        }
+      }));
+      return null;
+    }
+  };
+
+  const exportDiagnostics = (options) => {
+    if (!browser) return null;
+
+    try {
+      return voiceDiagnostics.exportDiagnosticData(options);
+    } catch (error) {
+      console.error('Failed to export diagnostic data', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Diagnostic export failed.'
+        }
+      }));
+      return null;
+    }
+  };
+
+  const teardown = () => {
+    if (!initialized) {
+      return;
+    }
+
+    initialized = false;
+
+    if (healthPoll) {
+      clearInterval(healthPoll);
+      healthPoll = null;
+    }
+
+    if (performancePoll) {
+      clearInterval(performancePoll);
+      performancePoll = null;
+    }
+
+    stopUxPolling();
+
+    if (diagnosticsStartedByStore && voiceDiagnostics.isMonitoring) {
+      voiceDiagnostics.stopMonitoring();
+    }
+
+    if (performanceStartedByStore && voicePerformanceMonitor.isActive) {
+      voicePerformanceMonitor.stopMonitoring();
+    }
+
+    if (uxStartedByStore && voiceUXMetricsTracker.isTracking) {
+      voiceUXMetricsTracker.stopTracking();
+    }
+
+    diagnosticsStartedByStore = false;
+    performanceStartedByStore = false;
+    uxStartedByStore = false;
+
+    set(createInitialState());
+  };
+
+  const getState = () => get({ subscribe });
+
+  return {
+    subscribe,
+    init,
+    teardown,
+    runHealthCheck,
+    toggleUXTracking,
+    updateThresholds,
+    generateCombinedReport,
+    exportPerformanceData,
+    exportUXData,
+    exportDiagnostics,
+    getState
+  };
+};
+
+export const voiceAnalyticsStore = createVoiceAnalyticsStore();

--- a/src/lib/modules/navigation/components/Navigation.svelte
+++ b/src/lib/modules/navigation/components/Navigation.svelte
@@ -60,6 +60,12 @@
           >
             Finance
           </a>
+          <a
+            href="/admin/voice-analytics"
+            class="dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 transition-colors"
+          >
+            Voice Analytics
+          </a>
         {/if}
         <ThemeToggle />
         <AuthButton />
@@ -138,6 +144,15 @@
             }}
           >
             Finance
+          </a>
+          <a
+            href="/admin/voice-analytics"
+            class="block px-3 py-2 dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700"
+            on:click={() => {
+              mobileMenuOpen = false;
+            }}
+          >
+            Voice Analytics
           </a>
         {/if}
         <div class="px-3 py-2">

--- a/src/routes/admin/voice-analytics/+page.server.js
+++ b/src/routes/admin/voice-analytics/+page.server.js
@@ -1,0 +1,27 @@
+import { redirect } from '@sveltejs/kit';
+import { STORAGE_KEYS } from '$shared/utils/constants';
+
+/**
+ * Server-side load for the admin voice analytics page.
+ * Ensures only admins can access the analytics dashboard.
+ */
+export const load = async ({ locals, cookies, url }) => {
+  let user = locals.user;
+
+  if (!user) {
+    const cookieUser = cookies.get(STORAGE_KEYS.USER);
+    if (cookieUser) {
+      try {
+        user = JSON.parse(cookieUser);
+      } catch (error) {
+        console.error('Failed to parse user cookie during voice analytics load', error);
+      }
+    }
+  }
+
+  if (!user || user.role !== 'admin') {
+    throw redirect(303, `/login?redirect=${url.pathname}`);
+  }
+
+  return { user };
+};

--- a/src/routes/admin/voice-analytics/+page.svelte
+++ b/src/routes/admin/voice-analytics/+page.svelte
@@ -1,0 +1,286 @@
+<script>
+  import { onMount, onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
+  import { get } from 'svelte/store';
+  import { voiceAnalyticsStore } from '$modules/admin/voice-analytics/voiceAnalyticsStore.js';
+  import HealthStatusPanel from '$modules/admin/voice-analytics/components/HealthStatusPanel.svelte';
+  import PerformanceAnalyticsPanel from '$modules/admin/voice-analytics/components/PerformanceAnalyticsPanel.svelte';
+  import UXMetricsPanel from '$modules/admin/voice-analytics/components/UXMetricsPanel.svelte';
+  import DiagnosticReportingPanel from '$modules/admin/voice-analytics/components/DiagnosticReportingPanel.svelte';
+
+  export let data;
+
+  let notification = '';
+  let notificationType = 'success';
+  let notificationTimeout;
+  let lastReportTimestamp = null;
+
+  const showNotification = (message, type = 'success') => {
+    notification = message;
+    notificationType = type;
+
+    if (notificationTimeout) {
+      clearTimeout(notificationTimeout);
+    }
+
+    notificationTimeout = setTimeout(() => {
+      notification = '';
+    }, 4000);
+  };
+
+  const downloadFile = (payload, filename, mimeType) => {
+    if (!browser || !payload) return;
+
+    const serialized = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
+    const dataBlob = new Blob([serialized], { type: mimeType });
+
+    const objectUrl = URL.createObjectURL(dataBlob);
+    const anchor = document.createElement('a');
+    anchor.href = objectUrl;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(objectUrl);
+  };
+
+  const handleHealthCheck = async () => {
+    try {
+      await voiceAnalyticsStore.runHealthCheck();
+      showNotification('Health check completed successfully.');
+    } catch (error) {
+      showNotification('Health check failed. Check console for details.', 'error');
+    }
+  };
+
+  const handleThresholdUpdate = (event) => {
+    const success = voiceAnalyticsStore.updateThresholds(event.detail.thresholds);
+    if (success) {
+      showNotification('Performance thresholds updated.');
+    } else {
+      showNotification('Failed to update performance thresholds.', 'error');
+    }
+  };
+
+  const handlePerformanceExport = (event) => {
+    const format = event.detail.format;
+    const exported = voiceAnalyticsStore.exportPerformanceData({ format });
+
+    if (!exported) {
+      showNotification('Failed to export performance data.', 'error');
+      return;
+    }
+
+    if (format === 'csv') {
+      downloadFile(exported, 'voice-performance.csv', 'text/csv');
+    } else {
+      downloadFile(JSON.stringify(exported, null, 2), 'voice-performance.json', 'application/json');
+    }
+    showNotification('Performance data exported.');
+  };
+
+  const handleUXExport = (event) => {
+    const format = event.detail.format;
+    const exported = voiceAnalyticsStore.exportUXData({ format });
+
+    if (!exported) {
+      showNotification('Failed to export UX data.', 'error');
+      return;
+    }
+
+    if (format === 'csv') {
+      downloadFile(exported, 'voice-ux-metrics.csv', 'text/csv');
+    } else {
+      downloadFile(JSON.stringify(exported, null, 2), 'voice-ux-metrics.json', 'application/json');
+    }
+    showNotification('UX data exported.');
+  };
+
+  const handleDiagnosticsExport = (event) => {
+    const format = event.detail.format;
+    const exported = voiceAnalyticsStore.exportDiagnostics({ format, includeRawMetrics: true });
+
+    if (!exported) {
+      showNotification('Failed to export diagnostic data.', 'error');
+      return;
+    }
+
+    if (format === 'csv') {
+      downloadFile(exported, 'voice-diagnostics.csv', 'text/csv');
+    } else {
+      downloadFile(JSON.stringify(exported, null, 2), 'voice-diagnostics.json', 'application/json');
+    }
+    showNotification('Diagnostic data exported.');
+  };
+
+  const handleCombinedExport = (event) => {
+    const format = event.detail.format;
+    const currentState = get(voiceAnalyticsStore);
+    const combined = {
+      generatedAt: Date.now(),
+      systemHealth: currentState.systemHealth,
+      performance: currentState.performance,
+      ux: currentState.ux
+    };
+
+    if (format === 'csv') {
+      const csv = voiceAnalyticsStore.exportDiagnostics({ format: 'csv', includeRawMetrics: true });
+      if (!csv) {
+        showNotification('Failed to export combined data.', 'error');
+        return;
+      }
+      downloadFile(csv, 'voice-analytics-combined.csv', 'text/csv');
+    } else {
+      downloadFile(
+        JSON.stringify(combined, null, 2),
+        'voice-analytics-combined.json',
+        'application/json'
+      );
+    }
+    showNotification('Combined analytics exported.');
+  };
+
+  const handleGenerateReport = async () => {
+    try {
+      const combinedReport = await voiceAnalyticsStore.generateCombinedReport();
+      if (!combinedReport) {
+        showNotification('Report generation did not return data.', 'error');
+        return;
+      }
+      lastReportTimestamp = combinedReport.timestamp ?? Date.now();
+      downloadFile(
+        JSON.stringify(combinedReport, null, 2),
+        `voice-diagnostic-report-${new Date(lastReportTimestamp).toISOString()}.json`,
+        'application/json'
+      );
+      showNotification('Diagnostic report generated and downloaded.');
+    } catch (error) {
+      showNotification('Failed to generate diagnostic report.', 'error');
+    }
+  };
+
+  const handleCopyIssues = async () => {
+    const { systemHealth } = get(voiceAnalyticsStore);
+    const issues = systemHealth?.issues ?? [];
+    if (!browser) return;
+
+    try {
+      await navigator.clipboard.writeText(
+        issues.length ? issues.join('\n') : 'No outstanding issues.'
+      );
+      showNotification('Issues copied to clipboard.');
+    } catch (error) {
+      console.error('Failed to copy issues to clipboard', error);
+      showNotification('Unable to copy issues to clipboard.', 'error');
+    }
+  };
+
+  const handleToggleTracking = async (event) => {
+    const enabled = event.detail.enabled;
+    const success = await voiceAnalyticsStore.toggleUXTracking(enabled);
+    if (success) {
+      showNotification(enabled ? 'Live UX tracking enabled.' : 'Live UX tracking disabled.');
+    } else {
+      showNotification('Unable to toggle UX tracking. Check logs for details.', 'error');
+    }
+  };
+
+  onMount(() => {
+    voiceAnalyticsStore.init();
+
+    return () => {
+      if (notificationTimeout) {
+        clearTimeout(notificationTimeout);
+      }
+      voiceAnalyticsStore.teardown();
+    };
+  });
+
+  onDestroy(() => {
+    if (notificationTimeout) {
+      clearTimeout(notificationTimeout);
+    }
+  });
+</script>
+
+<svelte:head>
+  <title>Admin • Voice Analytics</title>
+</svelte:head>
+
+<main class="max-w-7xl mx-auto px-6 py-10 space-y-8">
+  <header class="space-y-3">
+    <p class="text-sm text-stone-500 dark:text-gray-400">Administrator dashboard</p>
+    <h1 class="text-3xl font-bold text-stone-900 dark:text-white">Voice Analytics</h1>
+    <p class="text-stone-600 dark:text-gray-300 max-w-3xl">
+      Monitor system health, performance, and user experience in real time. Generate diagnostic
+      reports to keep the voice stack running smoothly.
+    </p>
+  </header>
+
+  {#if notification}
+    <div
+      class={`rounded-lg border px-4 py-3 text-sm shadow-sm ${
+        notificationType === 'error'
+          ? 'border-red-200 bg-red-50 text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200'
+          : 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-900/30 dark:text-emerald-200'
+      }`}
+    >
+      {notification}
+    </div>
+  {/if}
+
+  {#if data?.user}
+    <p class="text-sm text-stone-500 dark:text-gray-400">
+      Signed in as <span class="font-medium">{data.user.email}</span>
+    </p>
+  {/if}
+
+  {#if $voiceAnalyticsStore}
+    <div class="space-y-8">
+      <HealthStatusPanel
+        systemHealth={$voiceAnalyticsStore.systemHealth}
+        lastHealthCheck={$voiceAnalyticsStore.systemHealth?.lastHealthCheck}
+        monitoringActive={$voiceAnalyticsStore.monitoring.diagnostics}
+        runningHealthCheck={$voiceAnalyticsStore.ui.healthCheckRunning}
+        errorMessage={$voiceAnalyticsStore.errors?.diagnostics}
+        on:runHealthCheck={handleHealthCheck}
+      />
+
+      <PerformanceAnalyticsPanel
+        performance={$voiceAnalyticsStore.performance}
+        monitoringActive={$voiceAnalyticsStore.monitoring.performance}
+        lastUpdated={$voiceAnalyticsStore.lastUpdated}
+        errorMessage={$voiceAnalyticsStore.errors?.performance}
+        on:updateThresholds={handleThresholdUpdate}
+        on:export={handlePerformanceExport}
+      />
+
+      <UXMetricsPanel
+        ux={$voiceAnalyticsStore.ux}
+        lastUpdated={$voiceAnalyticsStore.lastUpdated}
+        errorMessage={$voiceAnalyticsStore.errors?.ux}
+        on:toggleTracking={handleToggleTracking}
+        on:export={handleUXExport}
+      />
+
+      <DiagnosticReportingPanel
+        systemHealth={$voiceAnalyticsStore.systemHealth}
+        performanceAnalysis={$voiceAnalyticsStore.performance.analysis}
+        uxSnapshot={{
+          metrics: $voiceAnalyticsStore.ux.metrics,
+          sessionHistory: $voiceAnalyticsStore.ux.sessionHistory,
+          realTimeIndicators: $voiceAnalyticsStore.ux.realTimeIndicators
+        }}
+        generatingReport={$voiceAnalyticsStore.ui.generatingReport}
+        lastGeneratedAt={lastReportTimestamp}
+        errorMessage={$voiceAnalyticsStore.errors?.diagnostics}
+        on:generate={handleGenerateReport}
+        on:copyIssues={handleCopyIssues}
+        on:exportDiagnostics={handleDiagnosticsExport}
+        on:export={handleCombinedExport}
+      />
+    </div>
+  {:else}
+    <p class="text-sm text-stone-500 dark:text-gray-400">Loading analytics…</p>
+  {/if}
+</main>


### PR DESCRIPTION
## Summary
- add a voice analytics store that orchestrates diagnostics, performance polling, UX tracking, reporting, and exports
- implement the admin-only voice analytics route with health, performance, UX, and reporting panels plus notification handling
- create reusable voice analytics UI components and surface the route in admin navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d976f0bbec8324a1ea1e0ad2772c1e