### PR TITLE
fix: prevent voice analytics monitoring crashes

### DIFF
--- a/src/lib/modules/admin/voice-analytics/components/DiagnosticReportingPanel.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/DiagnosticReportingPanel.svelte
@@ -1,0 +1,220 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+
+  export let systemHealth = { issues: [], recommendations: [] };
+  export let performanceAnalysis = {};
+  export let uxSnapshot = {};
+  export let generatingReport = false;
+  export let lastGeneratedAt = null;
+  export let errorMessage = '';
+
+  const dispatch = createEventDispatcher();
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return 'Not generated yet';
+    try {
+      return new Date(timestamp).toLocaleString();
+    } catch (error) {
+      return 'Unknown';
+    }
+  };
+
+  const handleGenerate = () => {
+    dispatch('generate');
+  };
+
+  const handleCopyIssues = () => {
+    dispatch('copyIssues');
+  };
+
+  const handleExportDiagnostics = (format) => {
+    dispatch('exportDiagnostics', { format });
+  };
+
+  const handleExportReports = (format) => {
+    dispatch('export', { format });
+  };
+</script>
+
+<section
+  class="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-sm"
+>
+  <header
+    class="px-6 py-5 border-b border-stone-200 dark:border-gray-700 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
+  >
+    <div>
+      <h2 class="text-2xl font-semibold text-stone-900 dark:text-white">Diagnostic Reporting</h2>
+      <p class="text-sm text-stone-500 dark:text-gray-400">
+        Generate comprehensive reports and export raw diagnostic data for further analysis.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-3">
+      <button
+        class="inline-flex items-center justify-center rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-70"
+        on:click={handleGenerate}
+        disabled={generatingReport}
+      >
+        {generatingReport ? 'Generating report…' : 'Generate full diagnostic report'}
+      </button>
+      <button
+        class="inline-flex items-center justify-center rounded-lg border border-stone-200 dark:border-gray-700 px-4 py-2 text-sm font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+        on:click={handleCopyIssues}
+      >
+        Copy current issues
+      </button>
+    </div>
+  </header>
+
+  <div class="px-6 py-6 space-y-6">
+    <div class="flex flex-col gap-1 text-sm text-stone-500 dark:text-gray-400">
+      <span
+        >Last generated: <span class="font-medium text-stone-700 dark:text-gray-200"
+          >{formatTimestamp(lastGeneratedAt)}</span
+        ></span
+      >
+    </div>
+
+    {#if errorMessage}
+      <p
+        class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200"
+      >
+        {errorMessage}
+      </p>
+    {/if}
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Open issues
+        </h3>
+        {#if systemHealth?.issues?.length}
+          <ul class="mt-3 space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#each systemHealth.issues as issue}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 px-3 py-2"
+              >
+                {issue}
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="mt-3 text-sm text-stone-500 dark:text-gray-400">
+            No outstanding issues recorded.
+          </p>
+        {/if}
+      </div>
+
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Quick exports
+        </h3>
+        <div class="flex flex-wrap gap-3">
+          <button
+            class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-sm font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+            on:click={() => handleExportDiagnostics('json')}
+          >
+            Download diagnostics JSON
+          </button>
+          <button
+            class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-sm font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+            on:click={() => handleExportDiagnostics('csv')}
+          >
+            Download diagnostics CSV
+          </button>
+          <button
+            class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-sm font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+            on:click={() => handleExportReports('json')}
+          >
+            Export combined report JSON
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-3"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Performance summary
+        </h3>
+        {#if performanceAnalysis && Object.keys(performanceAnalysis).length > 0}
+          <ul class="space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#each Object.entries(performanceAnalysis) as [metricName, details]}
+              {#if typeof details === 'object' && details !== null && metricName !== 'trends'}
+                <li
+                  class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+                >
+                  <div class="font-semibold text-stone-700 dark:text-gray-200">
+                    {metricName.replace(/([A-Z])/g, ' $1').trim()}
+                  </div>
+                  <div class="text-xs text-stone-500 dark:text-gray-400">
+                    Avg: {details.average?.toFixed?.(1) ?? '—'} • Min: {details.min?.toFixed?.(1) ??
+                      '—'} • Max: {details.max?.toFixed?.(1) ?? '—'}
+                  </div>
+                </li>
+              {/if}
+            {/each}
+          </ul>
+        {:else}
+          <p class="text-sm text-stone-500 dark:text-gray-400">
+            Performance metrics will appear after monitoring collects data.
+          </p>
+        {/if}
+      </div>
+
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-3"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          UX highlights
+        </h3>
+        {#if uxSnapshot && Object.keys(uxSnapshot).length > 0}
+          <ul class="space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#if uxSnapshot?.metrics?.satisfaction}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                Satisfaction score: {(
+                  (uxSnapshot.metrics.satisfaction.overallScore ?? 0) * 100
+                ).toFixed(0)}%
+              </li>
+            {/if}
+            {#if uxSnapshot?.metrics?.interaction}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                Successful interactions: {uxSnapshot.metrics.interaction.successfulInteractions ??
+                  0} / {uxSnapshot.metrics.interaction.totalInteractions ?? 0}
+              </li>
+            {/if}
+            {#if uxSnapshot?.sessionHistory?.length}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                Sessions tracked: {uxSnapshot.sessionHistory.length}
+              </li>
+            {/if}
+            {#if uxSnapshot?.realTimeIndicators}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                Live satisfaction: {(
+                  (uxSnapshot.realTimeIndicators.currentSatisfaction ?? 0) * 100
+                ).toFixed(0)}%
+              </li>
+            {/if}
+          </ul>
+        {:else}
+          <p class="text-sm text-stone-500 dark:text-gray-400">
+            UX metrics will populate once tracking is active.
+          </p>
+        {/if}
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/lib/modules/admin/voice-analytics/components/HealthStatusPanel.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/HealthStatusPanel.svelte
@@ -1,0 +1,177 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import StatusBadge from './StatusBadge.svelte';
+
+  export let systemHealth = {
+    overall: 'unknown',
+    components: {},
+    issues: [],
+    recommendations: []
+  };
+  export let lastHealthCheck = null;
+  export let monitoringActive = false;
+  export let runningHealthCheck = false;
+  export let errorMessage = '';
+
+  const dispatch = createEventDispatcher();
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return 'Never';
+    try {
+      return new Date(timestamp).toLocaleString();
+    } catch (error) {
+      return 'Unknown';
+    }
+  };
+
+  $: components = Object.entries(systemHealth?.components ?? {});
+</script>
+
+<section
+  class="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-sm"
+>
+  <header
+    class="px-6 py-5 border-b border-stone-200 dark:border-gray-700 flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between"
+  >
+    <div>
+      <h2 class="text-2xl font-semibold text-stone-900 dark:text-white">
+        System Health Monitoring
+      </h2>
+      <p class="text-sm text-stone-500 dark:text-gray-400">
+        Real-time diagnostics across all voice components with actionable insights.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-3">
+      <StatusBadge
+        status={monitoringActive ? (systemHealth?.overall ?? 'unknown') : 'inactive'}
+        label={monitoringActive
+          ? 'Overall: ' + (systemHealth?.overall ?? 'Unknown')
+          : 'Monitoring paused'}
+      />
+      <button
+        class="inline-flex items-center justify-center rounded-lg border border-transparent bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-70"
+        on:click={() => dispatch('runHealthCheck')}
+        disabled={runningHealthCheck}
+      >
+        {runningHealthCheck ? 'Running health check…' : 'Run health check'}
+      </button>
+    </div>
+  </header>
+
+  <div class="px-6 py-5 space-y-6">
+    <div class="flex flex-col gap-2 text-sm text-stone-500 dark:text-gray-400">
+      <div>
+        Last health check: <span class="font-medium text-stone-700 dark:text-gray-200"
+          >{formatTimestamp(lastHealthCheck)}</span
+        >
+      </div>
+      <div>
+        Monitoring status: <span class="font-medium text-stone-700 dark:text-gray-200"
+          >{monitoringActive ? 'Active' : 'Paused'}</span
+        >
+      </div>
+    </div>
+
+    {#if errorMessage}
+      <p
+        class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200"
+      >
+        {errorMessage}
+      </p>
+    {/if}
+
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {#if components.length === 0}
+        <p class="text-sm text-stone-500 dark:text-gray-400 md:col-span-2 xl:col-span-3">
+          No component diagnostics available yet.
+        </p>
+      {:else}
+        {#each components as [component, details]}
+          <div
+            class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4 space-y-3"
+          >
+            <div class="flex items-center justify-between">
+              <h3
+                class="text-sm font-semibold uppercase tracking-wide text-stone-600 dark:text-gray-300"
+              >
+                {component.replace(/([A-Z])/g, ' $1').trim()}
+              </h3>
+              <StatusBadge status={details?.status ?? 'unknown'} />
+            </div>
+            {#if details?.issues?.length}
+              <ul class="space-y-1 text-sm text-stone-600 dark:text-gray-300">
+                {#each details.issues as issue}
+                  <li class="flex items-start gap-2">
+                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+                    <span>{issue}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="text-sm text-stone-500 dark:text-gray-400">No current issues detected.</p>
+            {/if}
+            {#if details?.metrics}
+              <dl class="grid grid-cols-2 gap-2 text-xs text-stone-500 dark:text-gray-400">
+                {#each Object.entries(details.metrics) as [metricName, metricValue]}
+                  <div class="rounded-md bg-white dark:bg-gray-800/60 px-2 py-1">
+                    <dt class="font-medium text-stone-600 dark:text-gray-300">
+                      {metricName.replace(/([A-Z])/g, ' $1').trim()}
+                    </dt>
+                    <dd class="font-semibold text-stone-800 dark:text-white">
+                      {typeof metricValue === 'number' ? metricValue.toFixed(2) : metricValue}
+                    </dd>
+                  </div>
+                {/each}
+              </dl>
+            {/if}
+          </div>
+        {/each}
+      {/if}
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <div>
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Issues
+        </h3>
+        {#if systemHealth?.issues?.length}
+          <ul class="mt-3 space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#each systemHealth.issues as issue}
+              <li
+                class="flex items-start gap-2 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/40 px-3 py-2"
+              >
+                <span class="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-red-500"></span>
+                <span>{issue}</span>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="mt-3 text-sm text-stone-500 dark:text-gray-400">
+            No outstanding issues detected.
+          </p>
+        {/if}
+      </div>
+
+      <div>
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Recommendations
+        </h3>
+        {#if systemHealth?.recommendations?.length}
+          <ul class="mt-3 space-y-2 text-sm text-stone-600 dark:text-gray-300">
+            {#each systemHealth.recommendations as recommendation}
+              <li
+                class="rounded-lg border border-emerald-200 dark:border-emerald-900/60 bg-emerald-50 dark:bg-emerald-900/20 px-3 py-2"
+              >
+                {recommendation}
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="mt-3 text-sm text-stone-500 dark:text-gray-400">
+            Diagnostics look good—no immediate actions required.
+          </p>
+        {/if}
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/lib/modules/admin/voice-analytics/components/MetricSparkline.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/MetricSparkline.svelte
@@ -1,0 +1,97 @@
+<script>
+  export let points = [];
+  export let stroke = 'currentColor';
+  export let label = '';
+  export let value = null;
+  export let valueFormatter = (val) => (typeof val === 'number' ? val.toFixed(0) : val);
+
+  const width = 160;
+  const height = 56;
+  const padding = 6;
+
+  const componentId = `spark-${Math.random().toString(36).slice(2)}`;
+
+  const sanitizePoints = (input) =>
+    (input ?? []).filter(
+      (point) => point && typeof point.value === 'number' && Number.isFinite(point.value)
+    );
+
+  $: sanitized = sanitizePoints(points);
+  $: values = sanitized.map((point) => point.value);
+  $: min = values.length > 0 ? Math.min(...values) : 0;
+  $: max = values.length > 0 ? Math.max(...values) : 0;
+  $: range = max - min || 1;
+  $: pathD =
+    sanitized.length > 1
+      ? sanitized
+          .map((point, index) => {
+            const x = (index / (sanitized.length - 1)) * (width - padding * 2) + padding;
+            const normalized = (point.value - min) / range;
+            const y = height - padding - normalized * (height - padding * 2);
+            return `${index === 0 ? 'M' : 'L'}${x},${y}`;
+          })
+          .join(' ')
+      : '';
+  $: areaD =
+    sanitized.length > 1
+      ? `${pathD} L${width - padding},${height - padding} L${padding},${height - padding} Z`
+      : '';
+  $: latestValue = sanitized.length ? sanitized[sanitized.length - 1].value : value;
+</script>
+
+<div class="space-y-2">
+  {#if label}
+    <div class="flex items-center justify-between">
+      <p class="text-sm font-medium text-stone-600 dark:text-gray-300">{label}</p>
+      {#if latestValue !== undefined && latestValue !== null}
+        <span class="text-sm font-semibold text-stone-900 dark:text-white">
+          {valueFormatter(latestValue)}
+        </span>
+      {/if}
+    </div>
+  {/if}
+  <svg
+    viewBox={`0 0 ${width} ${height}`}
+    class="w-full h-16"
+    role="img"
+    aria-label={label ? `${label} trend sparkline` : 'Metric trend sparkline'}
+  >
+    <defs>
+      <linearGradient id={`${componentId}-gradient`} x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.25" />
+        <stop offset="100%" stop-color="#f59e0b" stop-opacity="0" />
+      </linearGradient>
+    </defs>
+    <rect
+      x="0"
+      y="0"
+      {width}
+      {height}
+      fill={`url(#${componentId}-gradient)`}
+      opacity={sanitized.length > 1 ? 1 : 0}
+      class="transition-opacity duration-200"
+    />
+    {#if sanitized.length > 1}
+      <path d={areaD} fill={`url(#${componentId}-gradient)`} class="opacity-70" />
+      <path
+        d={pathD}
+        fill="none"
+        {stroke}
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    {:else}
+      <line
+        x1={padding}
+        y1={height / 2}
+        x2={width - padding}
+        y2={height / 2}
+        {stroke}
+        stroke-width="2"
+        stroke-linecap="round"
+        class="opacity-50"
+      />
+    {/if}
+  </svg>
+</div>

--- a/src/lib/modules/admin/voice-analytics/components/PerformanceAnalyticsPanel.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/PerformanceAnalyticsPanel.svelte
@@ -1,0 +1,321 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import MetricSparkline from './MetricSparkline.svelte';
+  import StatusBadge from './StatusBadge.svelte';
+
+  export let performance = {
+    realTimeMetrics: null,
+    trends: {},
+    alerts: [],
+    thresholds: {},
+    analysis: {}
+  };
+  export let monitoringActive = false;
+  export let lastUpdated = null;
+  export let errorMessage = '';
+
+  const dispatch = createEventDispatcher();
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return 'Not updated yet';
+    try {
+      return new Date(timestamp).toLocaleTimeString();
+    } catch (error) {
+      return 'Unknown';
+    }
+  };
+
+  const formatMilliseconds = (value) =>
+    typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(0)} ms` : '—';
+
+  const formatMemory = (bytes) => {
+    if (typeof bytes !== 'number' || !Number.isFinite(bytes)) return '—';
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  };
+
+  let thresholdsSignature = '';
+  let editingThresholds = {
+    latency: 100,
+    memory: 50,
+    response: 2000
+  };
+
+  $: {
+    const signature = JSON.stringify(performance?.thresholds ?? {});
+    if (signature !== thresholdsSignature) {
+      thresholdsSignature = signature;
+      editingThresholds = {
+        latency: Math.round(performance?.thresholds?.audioProcessing?.latency ?? 100),
+        memory: Math.round(
+          (performance?.thresholds?.audioProcessing?.memoryUsage ?? 50 * 1024 * 1024) /
+            (1024 * 1024)
+        ),
+        response: Math.round(performance?.thresholds?.speechSynthesis?.responseTime ?? 2000)
+      };
+    }
+  }
+
+  const applyThresholds = () => {
+    dispatch('updateThresholds', {
+      thresholds: {
+        audioProcessing: {
+          latency: editingThresholds.latency,
+          memoryUsage: editingThresholds.memory * 1024 * 1024
+        },
+        speechSynthesis: {
+          responseTime: editingThresholds.response
+        }
+      }
+    });
+  };
+
+  const exportData = (format) => {
+    dispatch('export', { format });
+  };
+
+  $: realTimeMetrics = performance?.realTimeMetrics ?? {};
+  $: trends = performance?.trends ?? {};
+  $: alerts = performance?.alerts ?? [];
+  $: analysis = performance?.analysis ?? {};
+</script>
+
+<section
+  class="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-sm"
+>
+  <header
+    class="px-6 py-5 border-b border-stone-200 dark:border-gray-700 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
+  >
+    <div>
+      <h2 class="text-2xl font-semibold text-stone-900 dark:text-white">Performance Analytics</h2>
+      <p class="text-sm text-stone-500 dark:text-gray-400">
+        Latency, memory usage, and alert tracking for every voice subsystem.
+      </p>
+    </div>
+    <div class="flex items-center gap-3 flex-wrap">
+      <StatusBadge
+        status={monitoringActive ? 'healthy' : 'inactive'}
+        label={monitoringActive ? 'Monitoring active' : 'Monitoring paused'}
+      />
+      <div class="text-xs text-stone-500 dark:text-gray-400">
+        Last update: {formatTimestamp(lastUpdated)}
+      </div>
+      <div class="flex items-center gap-2">
+        <button
+          class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-xs font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+          on:click={() => exportData('json')}
+        >
+          Export JSON
+        </button>
+        <button
+          class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-xs font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+          on:click={() => exportData('csv')}
+        >
+          Export CSV
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <div class="px-6 py-6 space-y-6">
+    {#if errorMessage}
+      <p
+        class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200"
+      >
+        {errorMessage}
+      </p>
+    {/if}
+
+    <div class="grid gap-4 md:grid-cols-3">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <MetricSparkline
+          label="Audio latency"
+          points={trends.audioLatency}
+          stroke="#f59e0b"
+          valueFormatter={(value) => `${value.toFixed(0)} ms`}
+        />
+        <p class="mt-3 text-xs text-stone-500 dark:text-gray-400">
+          Current: {formatMilliseconds(realTimeMetrics?.audioProcessing?.currentLatency)}
+        </p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <MetricSparkline
+          label="Speech synthesis time"
+          points={trends.synthesisTime}
+          stroke="#6366f1"
+          valueFormatter={(value) => `${value.toFixed(0)} ms`}
+        />
+        <p class="mt-3 text-xs text-stone-500 dark:text-gray-400">
+          Current: {formatMilliseconds(realTimeMetrics?.speechSynthesis?.currentResponseTime)}
+        </p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <MetricSparkline
+          label="Memory usage"
+          points={trends.memoryUsage}
+          stroke="#10b981"
+          valueFormatter={(value) => `${(value / 1024 / 1024).toFixed(1)} MB`}
+        />
+        <p class="mt-3 text-xs text-stone-500 dark:text-gray-400">
+          Current: {formatMemory(realTimeMetrics?.audioProcessing?.memoryUsage)}
+        </p>
+      </div>
+    </div>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Thresholds
+        </h3>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <label class="space-y-1 text-sm text-stone-600 dark:text-gray-300">
+            <span class="font-medium">Max latency (ms)</span>
+            <input
+              type="number"
+              min="1"
+              bind:value={editingThresholds.latency}
+              class="w-full rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-stone-800 dark:text-white focus:border-amber-500 focus:ring-amber-500"
+            />
+          </label>
+          <label class="space-y-1 text-sm text-stone-600 dark:text-gray-300">
+            <span class="font-medium">Max memory (MB)</span>
+            <input
+              type="number"
+              min="1"
+              bind:value={editingThresholds.memory}
+              class="w-full rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-stone-800 dark:text-white focus:border-amber-500 focus:ring-amber-500"
+            />
+          </label>
+          <label class="space-y-1 text-sm text-stone-600 dark:text-gray-300 sm:col-span-2">
+            <span class="font-medium">Max speech response (ms)</span>
+            <input
+              type="number"
+              min="1"
+              bind:value={editingThresholds.response}
+              class="w-full rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-stone-800 dark:text-white focus:border-amber-500 focus:ring-amber-500"
+            />
+          </label>
+        </div>
+        <button
+          class="inline-flex items-center justify-center rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-600"
+          on:click={applyThresholds}
+        >
+          Apply thresholds
+        </button>
+      </div>
+
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Recent alerts
+        </h3>
+        {#if alerts.length === 0}
+          <p class="text-sm text-stone-500 dark:text-gray-400">
+            No alerts triggered in the latest sampling window.
+          </p>
+        {:else}
+          <ul class="space-y-3 text-sm">
+            {#each alerts as alert (alert.id)}
+              <li
+                class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 px-3 py-2"
+              >
+                <div class="flex items-center justify-between">
+                  <span class="font-semibold text-stone-700 dark:text-gray-200"
+                    >{alert.message}</span
+                  >
+                  <StatusBadge
+                    status={alert.severity ?? 'warning'}
+                    label={alert.severity ?? 'Warning'}
+                  />
+                </div>
+                <div class="mt-2 flex flex-wrap gap-3 text-xs text-stone-500 dark:text-gray-400">
+                  <span
+                    >{alert.timestamp ? new Date(alert.timestamp).toLocaleTimeString() : '—'}</span
+                  >
+                  {#if alert.threshold !== undefined && alert.value !== undefined}
+                    <span
+                      >Value: {typeof alert.value === 'number'
+                        ? alert.value.toFixed(1)
+                        : alert.value}</span
+                    >
+                    <span>Threshold: {alert.threshold}</span>
+                  {/if}
+                </div>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    </div>
+
+    {#if analysis?.trends}
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Trend summary
+        </h3>
+        <div class="text-sm text-stone-600 dark:text-gray-300">
+          <p>
+            Overall trend:
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{analysis.trends.overall ?? 'stable'}</span
+            >
+          </p>
+        </div>
+        <div class="grid gap-4 md:grid-cols-2 text-sm text-stone-600 dark:text-gray-300">
+          <div>
+            <h4 class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+              Areas of concern
+            </h4>
+            {#if analysis.trends.concerns?.length}
+              <ul class="mt-2 space-y-2">
+                {#each analysis.trends.concerns as concern}
+                  <li
+                    class="flex items-start gap-2 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 px-3 py-2"
+                  >
+                    <span class="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-red-500"></span>
+                    <span>{concern}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="mt-2 text-xs text-stone-500 dark:text-gray-400">
+                No degrading trends detected.
+              </p>
+            {/if}
+          </div>
+          <div>
+            <h4 class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+              Improvements
+            </h4>
+            {#if analysis.trends.improvements?.length}
+              <ul class="mt-2 space-y-2">
+                {#each analysis.trends.improvements as improvement}
+                  <li
+                    class="flex items-start gap-2 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 px-3 py-2"
+                  >
+                    <span class="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-500"></span>
+                    <span>{improvement}</span>
+                  </li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="mt-2 text-xs text-stone-500 dark:text-gray-400">
+                No major improvements recorded yet.
+              </p>
+            {/if}
+          </div>
+        </div>
+      </div>
+    {/if}
+  </div>
+</section>

--- a/src/lib/modules/admin/voice-analytics/components/StatusBadge.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/StatusBadge.svelte
@@ -1,0 +1,46 @@
+<script>
+  export let status = 'unknown';
+  export let label = '';
+
+  const STATUS_STYLES = {
+    healthy: {
+      badge: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+      dot: 'bg-emerald-500'
+    },
+    degraded: {
+      badge: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+      dot: 'bg-amber-500'
+    },
+    warning: {
+      badge: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+      dot: 'bg-amber-500'
+    },
+    critical: {
+      badge: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+      dot: 'bg-red-500'
+    },
+    error: {
+      badge: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+      dot: 'bg-red-500'
+    },
+    inactive: {
+      badge: 'bg-slate-100 text-slate-700 dark:bg-slate-800/60 dark:text-slate-200',
+      dot: 'bg-slate-400'
+    },
+    unknown: {
+      badge: 'bg-slate-100 text-slate-700 dark:bg-slate-800/60 dark:text-slate-200',
+      dot: 'bg-slate-400'
+    }
+  };
+
+  $: normalizedStatus = (status || 'unknown').toString().toLowerCase();
+  $: style = STATUS_STYLES[normalizedStatus] ?? STATUS_STYLES.unknown;
+  $: computedLabel = label || normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
+</script>
+
+<span
+  class={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium gap-2 ${style.badge}`}
+>
+  <span class={`w-2 h-2 rounded-full ${style.dot}`} aria-hidden="true"></span>
+  <span>{computedLabel}</span>
+</span>

--- a/src/lib/modules/admin/voice-analytics/components/UXMetricsPanel.svelte
+++ b/src/lib/modules/admin/voice-analytics/components/UXMetricsPanel.svelte
@@ -1,0 +1,294 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import StatusBadge from './StatusBadge.svelte';
+
+  export let ux = {
+    metrics: {},
+    realTimeIndicators: {},
+    sessionHistory: [],
+    currentSession: null,
+    trackingEnabled: false
+  };
+  export let lastUpdated = null;
+  export let errorMessage = '';
+
+  const dispatch = createEventDispatcher();
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return '—';
+    try {
+      return new Date(timestamp).toLocaleString();
+    } catch (error) {
+      return '—';
+    }
+  };
+
+  const formatDuration = (duration) => {
+    if (typeof duration !== 'number' || !Number.isFinite(duration) || duration <= 0) return '0m';
+    const minutes = duration / 60000;
+    if (minutes < 1) {
+      return `${(duration / 1000).toFixed(0)}s`;
+    }
+    return `${minutes.toFixed(1)}m`;
+  };
+
+  const safeRate = (success, total) => {
+    if (typeof success !== 'number' || typeof total !== 'number' || total <= 0) return 0;
+    return Math.min(1, Math.max(0, success / total));
+  };
+
+  const percentage = (value, decimals = 0) => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return '0%';
+    return `${(value * 100).toFixed(decimals)}%`;
+  };
+
+  const toggleTracking = (event) => {
+    dispatch('toggleTracking', { enabled: event.currentTarget.checked });
+  };
+
+  const exportData = (format) => {
+    dispatch('export', { format });
+  };
+
+  $: metrics = ux?.metrics ?? {};
+  $: indicators = ux?.realTimeIndicators ?? {};
+  $: sessionHistory = ux?.sessionHistory ?? [];
+  $: trackingEnabled = ux?.trackingEnabled ?? false;
+  $: currentSession = ux?.currentSession ?? null;
+
+  $: successRate = safeRate(
+    metrics?.interaction?.successfulInteractions,
+    metrics?.interaction?.totalInteractions
+  );
+  $: satisfactionScore =
+    metrics?.satisfaction?.overallScore ?? indicators?.currentSatisfaction ?? 0;
+  $: averageSessionDuration = metrics?.engagement?.sessionDuration ?? currentSession?.duration ?? 0;
+  $: returnRate = metrics?.engagement?.returnUserRate ?? 0;
+</script>
+
+<section
+  class="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-sm"
+>
+  <header
+    class="px-6 py-5 border-b border-stone-200 dark:border-gray-700 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
+  >
+    <div>
+      <h2 class="text-2xl font-semibold text-stone-900 dark:text-white">
+        User Experience Tracking
+      </h2>
+      <p class="text-sm text-stone-500 dark:text-gray-400">
+        Monitor interaction quality, satisfaction signals, and recent session history.
+      </p>
+    </div>
+    <div class="flex items-center gap-4 flex-wrap">
+      <label
+        class="inline-flex items-center gap-2 text-sm font-medium text-stone-600 dark:text-gray-300"
+      >
+        <input
+          type="checkbox"
+          checked={trackingEnabled}
+          on:change={toggleTracking}
+          class="h-4 w-4 rounded border-stone-300 text-amber-500 focus:ring-amber-500"
+        />
+        Live UX tracking
+      </label>
+      <StatusBadge
+        status={trackingEnabled ? 'healthy' : 'inactive'}
+        label={trackingEnabled ? 'Tracking active' : 'Tracking paused'}
+      />
+      <div class="flex items-center gap-2 text-xs text-stone-500 dark:text-gray-400">
+        <span>Last update: {formatTimestamp(lastUpdated)}</span>
+        <button
+          class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-xs font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+          on:click={() => exportData('json')}
+        >
+          Export JSON
+        </button>
+        <button
+          class="rounded-lg border border-stone-200 dark:border-gray-700 px-3 py-1.5 text-xs font-semibold text-stone-600 dark:text-gray-300 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+          on:click={() => exportData('csv')}
+        >
+          Export CSV
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <div class="px-6 py-6 space-y-6">
+    {#if errorMessage}
+      <p
+        class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200"
+      >
+        {errorMessage}
+      </p>
+    {/if}
+
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <p class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+          Success rate
+        </p>
+        <p class="mt-2 text-2xl font-semibold text-stone-900 dark:text-white">
+          {percentage(successRate, 0)}
+        </p>
+        <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">
+          {metrics?.interaction?.successfulInteractions ?? 0} successful interactions out of {metrics
+            ?.interaction?.totalInteractions ?? 0}
+        </p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <p class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+          Avg session duration
+        </p>
+        <p class="mt-2 text-2xl font-semibold text-stone-900 dark:text-white">
+          {formatDuration(averageSessionDuration)}
+        </p>
+        <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">Measured from recent sessions.</p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <p class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">
+          Satisfaction
+        </p>
+        <p class="mt-2 text-2xl font-semibold text-stone-900 dark:text-white">
+          {percentage(satisfactionScore, 0)}
+        </p>
+        <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">
+          Real-time satisfaction sentiment.
+        </p>
+      </div>
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-4"
+      >
+        <p class="text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400">Engagement</p>
+        <p class="mt-2 text-2xl font-semibold text-stone-900 dark:text-white">
+          {percentage(returnRate, 0)}
+        </p>
+        <p class="mt-1 text-xs text-stone-500 dark:text-gray-400">
+          Return user rate & ongoing engagement.
+        </p>
+      </div>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4 space-y-4"
+      >
+        <h3 class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide">
+          Current session snapshot
+        </h3>
+        {#if trackingEnabled && currentSession}
+          <dl class="grid gap-3 text-sm text-stone-600 dark:text-gray-300">
+            <div>
+              <dt class="font-semibold text-stone-700 dark:text-gray-200">Session ID</dt>
+              <dd class="mt-1 break-all">{currentSession.id}</dd>
+            </div>
+            <div>
+              <dt class="font-semibold text-stone-700 dark:text-gray-200">Started</dt>
+              <dd class="mt-1">{formatTimestamp(currentSession.startTime)}</dd>
+            </div>
+            <div>
+              <dt class="font-semibold text-stone-700 dark:text-gray-200">Duration</dt>
+              <dd class="mt-1">
+                {formatDuration(
+                  currentSession.startTime ? Math.max(0, Date.now() - currentSession.startTime) : 0
+                )}
+              </dd>
+            </div>
+          </dl>
+        {:else}
+          <p class="text-sm text-stone-500 dark:text-gray-400">
+            {trackingEnabled
+              ? 'Waiting for live interactions…'
+              : 'Enable tracking to capture live sessions.'}
+          </p>
+        {/if}
+
+        <div
+          class="rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-900/40 p-3 text-sm text-stone-600 dark:text-gray-300 space-y-1"
+        >
+          <div class="flex items-center justify-between">
+            <span>Engagement level</span>
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{indicators?.engagementLevel ?? '—'}</span
+            >
+          </div>
+          <div class="flex items-center justify-between">
+            <span>Frustration</span>
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{indicators?.userFrustration ?? '—'}</span
+            >
+          </div>
+          <div class="flex items-center justify-between">
+            <span>Cognitive load</span>
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{indicators?.cognitiveLoad ?? '—'}</span
+            >
+          </div>
+          <div class="flex items-center justify-between">
+            <span>Real-time satisfaction</span>
+            <span class="font-semibold text-stone-800 dark:text-white"
+              >{percentage(indicators?.currentSatisfaction ?? 0, 0)}</span
+            >
+          </div>
+        </div>
+      </div>
+
+      <div
+        class="rounded-xl border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-900/30 p-4"
+      >
+        <h3
+          class="text-sm font-semibold text-stone-700 dark:text-gray-200 uppercase tracking-wide mb-3"
+        >
+          Recent sessions
+        </h3>
+        {#if sessionHistory.length === 0}
+          <p class="text-sm text-stone-500 dark:text-gray-400">No session history captured yet.</p>
+        {:else}
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-stone-200 dark:divide-gray-700 text-sm">
+              <thead
+                class="bg-stone-50 dark:bg-gray-900/40 text-xs uppercase tracking-wide text-stone-500 dark:text-gray-400"
+              >
+                <tr>
+                  <th class="px-3 py-2 text-left font-semibold">Session</th>
+                  <th class="px-3 py-2 text-left font-semibold">Duration</th>
+                  <th class="px-3 py-2 text-left font-semibold">Success</th>
+                  <th class="px-3 py-2 text-left font-semibold">Errors</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-stone-200 dark:divide-gray-700">
+                {#each sessionHistory as session (session.id)}
+                  <tr class="bg-white dark:bg-gray-900/20">
+                    <td class="px-3 py-2 align-top">
+                      <div class="font-semibold text-stone-700 dark:text-gray-200">
+                        {session.id}
+                      </div>
+                      <div class="text-xs text-stone-500 dark:text-gray-400">
+                        {formatTimestamp(session.startTime)}
+                      </div>
+                    </td>
+                    <td class="px-3 py-2 align-top text-stone-600 dark:text-gray-300"
+                      >{formatDuration(session.duration)}</td
+                    >
+                    <td class="px-3 py-2 align-top text-stone-600 dark:text-gray-300">
+                      {percentage(session?.metrics?.efficiency?.interactionSuccessRate ?? 0, 0)}
+                    </td>
+                    <td class="px-3 py-2 align-top text-stone-600 dark:text-gray-300"
+                      >{session?.metrics?.errors?.totalErrors ?? 0}</td
+                    >
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/lib/modules/admin/voice-analytics/voiceAnalyticsStore.js
+++ b/src/lib/modules/admin/voice-analytics/voiceAnalyticsStore.js
@@ -1,0 +1,526 @@
+import { writable, get } from 'svelte/store';
+import { browser } from '$app/environment';
+import { voiceDiagnostics } from '$modules/chat/VoiceDiagnostics.js';
+import { voicePerformanceMonitor } from '$modules/chat/VoicePerformanceMonitor.js';
+import { voiceUXMetricsTracker } from '$modules/chat/VoiceUXMetricsTracker.js';
+
+const MAX_TREND_POINTS = 15;
+
+const trimSeries = (series = []) => {
+  if (!Array.isArray(series)) {
+    return [];
+  }
+  return series.slice(-MAX_TREND_POINTS);
+};
+
+const createInitialState = () => ({
+  systemHealth: {
+    overall: 'unknown',
+    components: {},
+    issues: [],
+    recommendations: [],
+    lastHealthCheck: null
+  },
+  performance: {
+    realTimeMetrics: null,
+    trends: {
+      audioLatency: [],
+      synthesisTime: [],
+      memoryUsage: [],
+      userInteractions: [],
+      errorRates: []
+    },
+    analysis: {},
+    alerts: [],
+    thresholds: voicePerformanceMonitor.thresholds
+  },
+  ux: {
+    metrics: voiceUXMetricsTracker.uxMetrics,
+    realTimeIndicators: voiceUXMetricsTracker.realTimeIndicators,
+    sessionHistory: [],
+    currentSession: null,
+    trackingEnabled: voiceUXMetricsTracker.isTracking
+  },
+  lastUpdated: null,
+  monitoring: {
+    diagnostics: voiceDiagnostics.isMonitoring,
+    performance: voicePerformanceMonitor.isActive,
+    uxTracking: voiceUXMetricsTracker.isTracking
+  },
+  errors: {},
+  ui: {
+    healthCheckRunning: false,
+    generatingReport: false
+  }
+});
+
+const createVoiceAnalyticsStore = () => {
+  const { subscribe, set, update } = writable(createInitialState());
+
+  let initialized = false;
+  let healthPoll = null;
+  let performancePoll = null;
+  let uxPoll = null;
+
+  let diagnosticsStartedByStore = false;
+  let performanceStartedByStore = false;
+  let uxStartedByStore = false;
+
+  const syncDiagnostics = () => {
+    if (!browser) return;
+
+    try {
+      const status = voiceDiagnostics.getCurrentStatus();
+
+      update((state) => ({
+        ...state,
+        systemHealth: {
+          ...state.systemHealth,
+          ...(status.systemHealth ?? {}),
+          lastHealthCheck: status.lastHealthCheck ?? state.systemHealth.lastHealthCheck
+        },
+        performance: {
+          ...state.performance,
+          analysis: status.performanceMetrics ?? state.performance.analysis,
+          thresholds: voicePerformanceMonitor.thresholds
+        },
+        monitoring: {
+          ...state.monitoring,
+          diagnostics: status.isMonitoring ?? voiceDiagnostics.isMonitoring,
+          performance: voicePerformanceMonitor.isActive,
+          uxTracking: voiceUXMetricsTracker.isTracking
+        },
+        errors: { ...state.errors, diagnostics: null },
+        lastUpdated: Date.now()
+      }));
+    } catch (error) {
+      console.error('Failed to sync diagnostics status', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Unable to retrieve system health data.'
+        }
+      }));
+    }
+  };
+
+  const syncPerformance = () => {
+    if (!browser) return;
+
+    try {
+      const metrics = voicePerformanceMonitor.getCurrentMetrics();
+      const buffer = metrics.performanceBuffer ?? {};
+
+      update((state) => ({
+        ...state,
+        performance: {
+          ...state.performance,
+          realTimeMetrics: metrics.realTimeMetrics ?? state.performance.realTimeMetrics,
+          trends: {
+            audioLatency: trimSeries(buffer.audioLatency),
+            synthesisTime: trimSeries(buffer.synthesisTime),
+            memoryUsage: trimSeries(buffer.memoryUsage),
+            userInteractions: trimSeries(buffer.userInteractions),
+            errorRates: trimSeries(buffer.errorRates)
+          },
+          alerts: metrics.alertHistory ?? state.performance.alerts,
+          thresholds: metrics.thresholds ?? voicePerformanceMonitor.thresholds,
+          analysis: state.performance.analysis
+        },
+        monitoring: {
+          ...state.monitoring,
+          performance: metrics.isActive ?? voicePerformanceMonitor.isActive
+        },
+        errors: { ...state.errors, performance: null },
+        lastUpdated: Date.now()
+      }));
+    } catch (error) {
+      console.error('Failed to sync performance metrics', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          performance: 'Unable to update performance metrics.'
+        }
+      }));
+    }
+  };
+
+  const syncUX = () => {
+    if (!browser) return;
+
+    try {
+      const snapshot = voiceUXMetricsTracker.getCurrentMetrics();
+      update((state) => ({
+        ...state,
+        ux: {
+          metrics: snapshot.uxMetrics ?? state.ux.metrics,
+          realTimeIndicators: snapshot.realTimeIndicators ?? state.ux.realTimeIndicators,
+          sessionHistory: snapshot.sessionHistory ?? state.ux.sessionHistory,
+          currentSession: snapshot.currentSession ?? state.ux.currentSession,
+          trackingEnabled: snapshot.isTracking ?? voiceUXMetricsTracker.isTracking
+        },
+        monitoring: {
+          ...state.monitoring,
+          uxTracking: snapshot.isTracking ?? voiceUXMetricsTracker.isTracking
+        },
+        errors: { ...state.errors, ux: null },
+        lastUpdated: Date.now()
+      }));
+    } catch (error) {
+      console.error('Failed to sync UX metrics', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          ux: 'Unable to update UX tracking metrics.'
+        }
+      }));
+    }
+  };
+
+  const startUxPolling = () => {
+    if (uxPoll || !browser) return;
+
+    uxPoll = setInterval(() => {
+      syncUX();
+    }, 5000);
+  };
+
+  const stopUxPolling = () => {
+    if (uxPoll) {
+      clearInterval(uxPoll);
+      uxPoll = null;
+    }
+  };
+
+  const init = () => {
+    if (!browser || initialized) {
+      return;
+    }
+
+    initialized = true;
+
+    set(createInitialState());
+
+    try {
+      if (!voiceDiagnostics.isMonitoring) {
+        voiceDiagnostics.startMonitoring({ enableRealTimeAlerts: true });
+        diagnosticsStartedByStore = true;
+      }
+    } catch (error) {
+      console.error('Failed to start diagnostics monitoring', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Diagnostics monitoring could not be started.'
+        }
+      }));
+    }
+
+    try {
+      if (!voicePerformanceMonitor.isActive) {
+        voicePerformanceMonitor.startMonitoring({ enableAlerts: true });
+        performanceStartedByStore = true;
+      }
+    } catch (error) {
+      console.error('Failed to start performance monitoring', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          performance: 'Performance monitoring could not be started.'
+        }
+      }));
+    }
+
+    syncDiagnostics();
+    syncPerformance();
+    syncUX();
+
+    voiceDiagnostics
+      .performHealthCheck()
+      .then((result) => {
+        update((state) => ({
+          ...state,
+          systemHealth: {
+            ...state.systemHealth,
+            ...(result ?? {}),
+            lastHealthCheck: result?.timestamp ?? Date.now()
+          },
+          errors: { ...state.errors, diagnostics: null },
+          lastUpdated: Date.now()
+        }));
+      })
+      .catch((error) => {
+        console.error('Initial health check failed', error);
+        update((state) => ({
+          ...state,
+          errors: {
+            ...state.errors,
+            diagnostics: 'Initial health check failed. Try running it again.'
+          }
+        }));
+      });
+
+    healthPoll = setInterval(() => {
+      syncDiagnostics();
+    }, 30000);
+
+    performancePoll = setInterval(() => {
+      syncPerformance();
+    }, 2000);
+
+    if (voiceUXMetricsTracker.isTracking) {
+      startUxPolling();
+    }
+  };
+
+  const runHealthCheck = async () => {
+    if (!browser) return null;
+
+    update((state) => ({
+      ...state,
+      ui: { ...state.ui, healthCheckRunning: true }
+    }));
+
+    try {
+      const result = await voiceDiagnostics.performHealthCheck();
+      update((state) => ({
+        ...state,
+        systemHealth: {
+          ...state.systemHealth,
+          ...(result ?? {}),
+          lastHealthCheck: result?.timestamp ?? Date.now()
+        },
+        errors: { ...state.errors, diagnostics: null },
+        ui: { ...state.ui, healthCheckRunning: false },
+        lastUpdated: Date.now()
+      }));
+      return result;
+    } catch (error) {
+      console.error('Manual health check failed', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Health check failed. Please try again.'
+        },
+        ui: { ...state.ui, healthCheckRunning: false }
+      }));
+      throw error;
+    }
+  };
+
+  const toggleUXTracking = async (enable) => {
+    if (!browser) return false;
+
+    try {
+      if (enable) {
+        voiceUXMetricsTracker.startTracking();
+        uxStartedByStore = true;
+        syncUX();
+        startUxPolling();
+        return true;
+      } else {
+        if (voiceUXMetricsTracker.isTracking) {
+          voiceUXMetricsTracker.stopTracking();
+        }
+        voiceUXMetricsTracker.resetMetrics();
+        syncUX();
+        stopUxPolling();
+        uxStartedByStore = false;
+        return true;
+      }
+    } catch (error) {
+      console.error('Failed to toggle UX tracking', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          ux: enable
+            ? 'Unable to start UX tracking. Check browser permissions.'
+            : 'Unable to stop UX tracking cleanly.'
+        }
+      }));
+      return false;
+    }
+  };
+
+  const updateThresholds = (thresholds) => {
+    if (!browser || !thresholds) return false;
+
+    try {
+      voicePerformanceMonitor.updateThresholds(thresholds);
+      syncPerformance();
+      return true;
+    } catch (error) {
+      console.error('Failed to update performance thresholds', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          performance: 'Could not update performance thresholds.'
+        }
+      }));
+      return false;
+    }
+  };
+
+  const generateCombinedReport = async () => {
+    if (!browser) return null;
+
+    update((state) => ({
+      ...state,
+      ui: { ...state.ui, generatingReport: true }
+    }));
+
+    try {
+      const report = await voiceDiagnostics.generateDiagnosticReport({
+        includeHealthCheck: true,
+        includePerformanceMetrics: true,
+        includeUXMetrics: true,
+        includeRecommendations: true
+      });
+
+      const performanceSnapshot = voicePerformanceMonitor.getCurrentMetrics();
+      const uxSnapshot = voiceUXMetricsTracker.getCurrentMetrics();
+
+      const combinedReport = {
+        ...report,
+        performanceSnapshot,
+        uxSnapshot
+      };
+
+      update((state) => ({
+        ...state,
+        ui: { ...state.ui, generatingReport: false }
+      }));
+
+      return combinedReport;
+    } catch (error) {
+      console.error('Failed to generate diagnostic report', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Unable to generate diagnostic report.'
+        },
+        ui: { ...state.ui, generatingReport: false }
+      }));
+      throw error;
+    }
+  };
+
+  const exportPerformanceData = (options) => {
+    if (!browser) return null;
+
+    try {
+      return voicePerformanceMonitor.exportPerformanceData(options);
+    } catch (error) {
+      console.error('Failed to export performance data', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          performance: 'Performance data export failed.'
+        }
+      }));
+      return null;
+    }
+  };
+
+  const exportUXData = (options) => {
+    if (!browser) return null;
+
+    try {
+      return voiceUXMetricsTracker.exportUXData(options);
+    } catch (error) {
+      console.error('Failed to export UX data', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          ux: 'UX data export failed.'
+        }
+      }));
+      return null;
+    }
+  };
+
+  const exportDiagnostics = (options) => {
+    if (!browser) return null;
+
+    try {
+      return voiceDiagnostics.exportDiagnosticData(options);
+    } catch (error) {
+      console.error('Failed to export diagnostic data', error);
+      update((state) => ({
+        ...state,
+        errors: {
+          ...state.errors,
+          diagnostics: 'Diagnostic export failed.'
+        }
+      }));
+      return null;
+    }
+  };
+
+  const teardown = () => {
+    if (!initialized) {
+      return;
+    }
+
+    initialized = false;
+
+    if (healthPoll) {
+      clearInterval(healthPoll);
+      healthPoll = null;
+    }
+
+    if (performancePoll) {
+      clearInterval(performancePoll);
+      performancePoll = null;
+    }
+
+    stopUxPolling();
+
+    if (diagnosticsStartedByStore && voiceDiagnostics.isMonitoring) {
+      voiceDiagnostics.stopMonitoring();
+    }
+
+    if (performanceStartedByStore && voicePerformanceMonitor.isActive) {
+      voicePerformanceMonitor.stopMonitoring();
+    }
+
+    if (uxStartedByStore && voiceUXMetricsTracker.isTracking) {
+      voiceUXMetricsTracker.stopTracking();
+    }
+
+    diagnosticsStartedByStore = false;
+    performanceStartedByStore = false;
+    uxStartedByStore = false;
+
+    set(createInitialState());
+  };
+
+  const getState = () => get({ subscribe });
+
+  return {
+    subscribe,
+    init,
+    teardown,
+    runHealthCheck,
+    toggleUXTracking,
+    updateThresholds,
+    generateCombinedReport,
+    exportPerformanceData,
+    exportUXData,
+    exportDiagnostics,
+    getState
+  };
+};
+
+export const voiceAnalyticsStore = createVoiceAnalyticsStore();

--- a/src/lib/modules/chat/AudioBufferManager.js
+++ b/src/lib/modules/chat/AudioBufferManager.js
@@ -12,31 +12,31 @@ export class AudioBufferManager {
     this.audioContext = null;
     this.gainNodes = new Map(); // For volume control and fading
     this.isInitialized = false;
-    
+
     // Audio processing settings - optimized
     this.silencePadding = 0.05; // Reduced padding for faster playback
     this.fadeInDuration = 0.03; // Faster fade-in
     this.fadeOutDuration = 0.03; // Faster fade-out
-    
+
     // Performance optimization settings
     this.maxConcurrentBuffers = 5; // Limit concurrent processing
     this.bufferCleanupInterval = 30000; // 30 seconds
     this.performanceMode = 'balanced'; // 'fast', 'balanced', 'quality'
-    
+
     // Worker for heavy processing (if available)
     this.audioWorker = null;
     this.initializeAudioWorker();
-    
+
     // Performance monitoring
     this.performanceMetrics = {
       bufferProcessingTime: [],
       playbackLatency: [],
       memoryUsage: 0
     };
-    
+
     // Start cleanup interval
     this.startCleanupInterval();
-    
+
     console.log('AudioBufferManager initialized with performance optimizations');
   }
 
@@ -67,14 +67,14 @@ export class AudioBufferManager {
           };
         }
       `;
-      
+
       const blob = new Blob([workerCode], { type: 'application/javascript' });
       this.audioWorker = new Worker(URL.createObjectURL(blob));
-      
+
       this.audioWorker.onmessage = (e) => {
         this.handleWorkerMessage(e.data);
       };
-      
+
       console.log('Audio worker initialized for performance optimization');
     } catch (error) {
       console.warn('Audio worker not available, using main thread processing:', error);
@@ -86,8 +86,8 @@ export class AudioBufferManager {
    * @param {Object} message - Worker message
    */
   handleWorkerMessage(message) {
-    const { type, result } = message;
-    
+    const { type } = message;
+
     switch (type) {
       case 'audioProcessed':
         // Handle processed audio result
@@ -110,7 +110,7 @@ export class AudioBufferManager {
   performCleanup() {
     const now = Date.now();
     const maxAge = 60000; // 1 minute
-    
+
     // Clean old buffers
     for (const [id, bufferedAudio] of this.preloadBuffer.entries()) {
       const age = now - bufferedAudio.metadata.processedAt;
@@ -118,18 +118,20 @@ export class AudioBufferManager {
         this.preloadBuffer.delete(id);
       }
     }
-    
+
     // Clean old gain nodes
-    for (const [id, gainNode] of this.gainNodes.entries()) {
+    for (const id of this.gainNodes.keys()) {
       if (!this.preloadBuffer.has(id)) {
         this.gainNodes.delete(id);
       }
     }
-    
+
     // Update memory usage metric
     this.performanceMetrics.memoryUsage = this.preloadBuffer.size;
-    
-    console.log(`Cleanup completed: ${this.preloadBuffer.size} buffers, ${this.gainNodes.size} gain nodes`);
+
+    console.log(
+      `Cleanup completed: ${this.preloadBuffer.size} buffers, ${this.gainNodes.size} gain nodes`
+    );
   }
 
   /**
@@ -139,12 +141,12 @@ export class AudioBufferManager {
   async initialize(audioContext) {
     try {
       this.audioContext = audioContext;
-      
+
       // Ensure audio context is running
       if (this.audioContext.state === 'suspended') {
         await this.audioContext.resume();
       }
-      
+
       this.isInitialized = true;
       console.log('AudioBufferManager initialized with audio context');
     } catch (error) {
@@ -161,7 +163,7 @@ export class AudioBufferManager {
    */
   async bufferAudio(audioBlob, metadata = {}) {
     const startTime = performance.now();
-    
+
     try {
       if (!this.isInitialized) {
         throw new Error('AudioBufferManager not initialized');
@@ -176,7 +178,7 @@ export class AudioBufferManager {
 
       // Optimize based on performance mode
       const processedBuffer = await this.optimizedAudioProcessing(audioBlob, metadata);
-      
+
       // Create buffered audio object
       const bufferedAudio = {
         id: metadata.id || `audio_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
@@ -201,16 +203,18 @@ export class AudioBufferManager {
 
       // Cache the buffered audio
       this.preloadBuffer.set(bufferedAudio.id, bufferedAudio);
-      
+
       // Update performance metrics
       this.updatePerformanceMetrics('bufferProcessingTime', performance.now() - startTime);
-      
-      console.log(`Audio buffered successfully: ${bufferedAudio.id}, duration: ${processedBuffer.duration.toFixed(2)}s, processing: ${(performance.now() - startTime).toFixed(1)}ms`);
-      
+
+      console.log(
+        `Audio buffered successfully: ${bufferedAudio.id}, duration: ${processedBuffer.duration.toFixed(2)}s, processing: ${(performance.now() - startTime).toFixed(1)}ms`
+      );
+
       return bufferedAudio;
     } catch (error) {
       console.error('Error buffering audio:', error);
-      
+
       // Return fallback object for direct playback
       return {
         id: metadata.id || `fallback_${Date.now()}`,
@@ -241,21 +245,21 @@ export class AudioBufferManager {
   async optimizedAudioProcessing(audioBlob, metadata) {
     // Convert blob to array buffer
     const arrayBuffer = await audioBlob.arrayBuffer();
-    
+
     // Decode audio data
     const audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
-    
+
     // Apply processing based on performance mode
     switch (this.performanceMode) {
       case 'fast':
         return audioBuffer; // No additional processing for speed
-        
+
       case 'balanced':
         return await this.processAudioBufferBalanced(audioBuffer, metadata);
-        
+
       case 'quality':
         return await this.processAudioBuffer(audioBuffer, metadata);
-        
+
       default:
         return await this.processAudioBufferBalanced(audioBuffer, metadata);
     }
@@ -271,13 +275,17 @@ export class AudioBufferManager {
     try {
       const { sampleRate, numberOfChannels } = audioBuffer;
       const originalLength = audioBuffer.length;
-      
+
+      const silencePaddingConfig = metadata?.silencePadding ?? this.silencePadding;
+      const fadeInDurationConfig = metadata?.fadeInDuration ?? this.fadeInDuration;
+      const fadeOutDurationConfig = metadata?.fadeOutDuration ?? this.fadeOutDuration;
+
       // Reduced padding for performance
-      const silenceSamples = Math.floor(this.silencePadding * sampleRate);
-      const fadeInSamples = Math.floor(this.fadeInDuration * sampleRate);
-      const fadeOutSamples = Math.floor(this.fadeOutDuration * sampleRate);
+      const silenceSamples = Math.floor(silencePaddingConfig * sampleRate);
+      const fadeInSamples = Math.floor(fadeInDurationConfig * sampleRate);
+      const fadeOutSamples = Math.floor(fadeOutDurationConfig * sampleRate);
       const newLength = originalLength + silenceSamples; // Only padding at end
-      
+
       // Create new buffer
       const processedBuffer = this.audioContext.createBuffer(
         numberOfChannels,
@@ -289,24 +297,24 @@ export class AudioBufferManager {
       for (let channel = 0; channel < numberOfChannels; channel++) {
         const originalData = audioBuffer.getChannelData(channel);
         const processedData = processedBuffer.getChannelData(channel);
-        
+
         // Copy original audio data with minimal processing
         for (let i = 0; i < originalLength; i++) {
           let sample = originalData[i];
-          
+
           // Apply fade-in (first 10% of samples)
           if (i < fadeInSamples) {
             sample *= i / fadeInSamples;
           }
-          
+
           // Apply fade-out (last 10% of samples)
           if (i >= originalLength - fadeOutSamples) {
             sample *= (originalLength - i) / fadeOutSamples;
           }
-          
+
           processedData[i] = sample;
         }
-        
+
         // Add minimal silence padding at the end
         for (let i = originalLength; i < newLength; i++) {
           processedData[i] = 0;
@@ -326,7 +334,7 @@ export class AudioBufferManager {
   async makeSpaceForNewBuffer() {
     const entries = Array.from(this.preloadBuffer.entries());
     entries.sort((a, b) => a[1].metadata.processedAt - b[1].metadata.processedAt);
-    
+
     // Remove oldest buffer
     if (entries.length > 0) {
       const [oldestId] = entries[0];
@@ -345,9 +353,9 @@ export class AudioBufferManager {
     if (!this.performanceMetrics[metric]) {
       this.performanceMetrics[metric] = [];
     }
-    
+
     this.performanceMetrics[metric].push(value);
-    
+
     // Keep only last 100 measurements
     if (this.performanceMetrics[metric].length > 100) {
       this.performanceMetrics[metric].shift();
@@ -375,13 +383,17 @@ export class AudioBufferManager {
     try {
       const { sampleRate, numberOfChannels } = audioBuffer;
       const originalLength = audioBuffer.length;
-      
+
+      const silencePaddingConfig = metadata?.silencePadding ?? this.silencePadding;
+      const fadeInDurationConfig = metadata?.fadeInDuration ?? this.fadeInDuration;
+      const fadeOutDurationConfig = metadata?.fadeOutDuration ?? this.fadeOutDuration;
+
       // Calculate new buffer length with padding
-      const silenceSamples = Math.floor(this.silencePadding * sampleRate);
-      const fadeInSamples = Math.floor(this.fadeInDuration * sampleRate);
-      const fadeOutSamples = Math.floor(this.fadeOutDuration * sampleRate);
-      const newLength = originalLength + (silenceSamples * 2); // Padding at start and end
-      
+      const silenceSamples = Math.floor(silencePaddingConfig * sampleRate);
+      const fadeInSamples = Math.floor(fadeInDurationConfig * sampleRate);
+      const fadeOutSamples = Math.floor(fadeOutDurationConfig * sampleRate);
+      const newLength = originalLength + silenceSamples * 2; // Padding at start and end
+
       // Create new buffer with padding
       const processedBuffer = this.audioContext.createBuffer(
         numberOfChannels,
@@ -393,32 +405,32 @@ export class AudioBufferManager {
       for (let channel = 0; channel < numberOfChannels; channel++) {
         const originalData = audioBuffer.getChannelData(channel);
         const processedData = processedBuffer.getChannelData(channel);
-        
+
         // Add silence padding at the beginning
         for (let i = 0; i < silenceSamples; i++) {
           processedData[i] = 0;
         }
-        
+
         // Copy original audio data with fade effects
         for (let i = 0; i < originalLength; i++) {
           let sample = originalData[i];
           const targetIndex = i + silenceSamples;
-          
+
           // Apply fade-in
           if (i < fadeInSamples) {
             const fadeMultiplier = i / fadeInSamples;
             sample *= fadeMultiplier;
           }
-          
+
           // Apply fade-out
           if (i >= originalLength - fadeOutSamples) {
             const fadeMultiplier = (originalLength - i) / fadeOutSamples;
             sample *= fadeMultiplier;
           }
-          
+
           processedData[targetIndex] = sample;
         }
-        
+
         // Add silence padding at the end
         for (let i = originalLength + silenceSamples; i < newLength; i++) {
           processedData[i] = 0;
@@ -445,12 +457,7 @@ export class AudioBufferManager {
         throw new Error('AudioBufferManager not initialized');
       }
 
-      const {
-        volume = 1.0,
-        startTime = 0,
-        crossfadeFrom = null,
-        onEnded = null
-      } = options;
+      const { volume = 1.0, startTime = 0, crossfadeFrom = null, onEnded = null } = options;
 
       console.log(`Playing buffered audio: ${bufferedAudio.id}`);
 
@@ -488,7 +495,7 @@ export class AudioBufferManager {
       source.start(playStartTime);
 
       console.log(`Audio playback started: ${bufferedAudio.id} at ${playStartTime}`);
-      
+
       return source;
     } catch (error) {
       console.error('Error playing buffered audio:', error);
@@ -511,7 +518,7 @@ export class AudioBufferManager {
         const fromGainNode = this.gainNodes.get(fromSource);
         fromGainNode.gain.setValueAtTime(fromGainNode.gain.value, currentTime);
         fromGainNode.gain.linearRampToValueAtTime(0, currentTime + crossfadeDurationSec);
-        
+
         // Stop the previous source after fade out
         setTimeout(() => {
           try {
@@ -578,7 +585,7 @@ export class AudioBufferManager {
 
       for (const [id, bufferedAudio] of this.preloadBuffer.entries()) {
         const age = now - bufferedAudio.metadata.processedAt;
-        
+
         if (!maxAge || age > maxAge) {
           this.preloadBuffer.delete(id);
           clearedCount++;
@@ -608,22 +615,22 @@ export class AudioBufferManager {
     let oldestTime = Infinity;
     let newestTime = 0;
 
-    for (const [id, bufferedAudio] of this.preloadBuffer.entries()) {
-      const size = bufferedAudio.originalBlob.size;
-      const duration = bufferedAudio.metadata.duration || 0;
-      const processedAt = bufferedAudio.metadata.processedAt;
+    for (const [audioId, bufferedAudio] of this.preloadBuffer.entries()) {
+      const size = bufferedAudio?.originalBlob?.size ?? 0;
+      const duration = bufferedAudio?.metadata?.duration ?? 0;
+      const processedAt = bufferedAudio?.metadata?.processedAt ?? 0;
 
       stats.totalSize += size;
       totalDuration += duration;
 
-      if (processedAt < oldestTime) {
+      if (processedAt && processedAt < oldestTime) {
         oldestTime = processedAt;
-        stats.oldestItem = id;
+        stats.oldestItem = audioId;
       }
 
-      if (processedAt > newestTime) {
+      if (processedAt && processedAt > newestTime) {
         newestTime = processedAt;
-        stats.newestItem = id;
+        stats.newestItem = audioId;
       }
     }
 
@@ -638,7 +645,7 @@ export class AudioBufferManager {
   cleanup() {
     try {
       // Stop all active audio sources
-      for (const [id, gainNode] of this.gainNodes.entries()) {
+      for (const gainNode of this.gainNodes.values()) {
         try {
           gainNode.gain.setValueAtTime(0, this.audioContext.currentTime);
         } catch (e) {
@@ -649,9 +656,9 @@ export class AudioBufferManager {
       // Clear all buffers and caches
       this.preloadBuffer.clear();
       this.gainNodes.clear();
-      
+
       this.isInitialized = false;
-      
+
       console.log('AudioBufferManager cleaned up');
     } catch (error) {
       console.error('Error during AudioBufferManager cleanup:', error);

--- a/src/lib/modules/chat/VoiceUXMetricsTracker.js
+++ b/src/lib/modules/chat/VoiceUXMetricsTracker.js
@@ -12,16 +12,16 @@ export class VoiceUXMetricsTracker {
   constructor() {
     this.trackerId = `ux_tracker_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
     this.isTracking = false;
-    
+
     // Session tracking
     this.currentSession = null;
     this.sessionHistory = [];
     this.maxSessionHistory = 50;
-    
+
     // Interaction tracking
     this.interactionBuffer = [];
     this.maxInteractionBuffer = 1000;
-    
+
     // UX metrics configuration
     this.metricsConfig = {
       trackingInterval: 5000, // 5 seconds
@@ -34,7 +34,7 @@ export class VoiceUXMetricsTracker {
         accessibilityCompliance: true
       }
     };
-    
+
     // UX metrics storage
     this.uxMetrics = {
       // Effectiveness metrics
@@ -44,7 +44,7 @@ export class VoiceUXMetricsTracker {
         abandonedTasks: 0,
         averageCompletionTime: 0
       },
-      
+
       // Efficiency metrics
       interaction: {
         totalInteractions: 0,
@@ -53,7 +53,7 @@ export class VoiceUXMetricsTracker {
         errorRate: 0,
         recoveryTime: 0
       },
-      
+
       // Satisfaction metrics
       satisfaction: {
         overallScore: 0,
@@ -62,7 +62,7 @@ export class VoiceUXMetricsTracker {
         naturalness: 0,
         userFeedback: []
       },
-      
+
       // Usability metrics
       usability: {
         learnabilityScore: 0,
@@ -71,7 +71,7 @@ export class VoiceUXMetricsTracker {
         accessibilityScore: 0,
         cognitiveLoadScore: 0
       },
-      
+
       // Engagement metrics
       engagement: {
         sessionDuration: 0,
@@ -81,7 +81,7 @@ export class VoiceUXMetricsTracker {
         dropOffPoints: []
       }
     };
-    
+
     // Real-time UX indicators
     this.realTimeIndicators = {
       currentSatisfaction: 0,
@@ -90,10 +90,10 @@ export class VoiceUXMetricsTracker {
       userFrustration: 'none',
       engagementLevel: 'medium'
     };
-    
+
     // Event listeners for UX tracking
     this.eventListeners = new Map();
-    
+
     console.log('VoiceUXMetricsTracker initialized:', this.trackerId);
   }
 
@@ -107,27 +107,23 @@ export class VoiceUXMetricsTracker {
       return;
     }
 
-    const {
-      sessionId = null,
-      userId = 'anonymous',
-      trackingLevel = 'comprehensive'
-    } = options;
+    const { sessionId = null, userId = 'anonymous', trackingLevel = 'comprehensive' } = options;
 
     this.isTracking = true;
-    
+
     // Start new session
     this.startSession({
       sessionId: sessionId,
       userId: userId,
       trackingLevel: trackingLevel
     });
-    
+
     // Set up event listeners
     this.setupEventListeners();
-    
+
     // Start periodic UX assessment
     this.startPeriodicAssessment();
-    
+
     console.log('UX metrics tracking started for session:', this.currentSession?.id);
   }
 
@@ -140,18 +136,18 @@ export class VoiceUXMetricsTracker {
     }
 
     this.isTracking = false;
-    
+
     // End current session
     if (this.currentSession) {
       this.endSession();
     }
-    
+
     // Remove event listeners
     this.removeEventListeners();
-    
+
     // Stop periodic assessment
     this.stopPeriodicAssessment();
-    
+
     console.log('UX metrics tracking stopped');
   }
 
@@ -160,8 +156,10 @@ export class VoiceUXMetricsTracker {
    * @param {Object} sessionData - Session data
    */
   startSession(sessionData) {
-    const sessionId = sessionData.sessionId || `ux_session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-    
+    const sessionId =
+      sessionData.sessionId ||
+      `ux_session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
     this.currentSession = {
       id: sessionId,
       userId: sessionData.userId || 'anonymous',
@@ -169,13 +167,13 @@ export class VoiceUXMetricsTracker {
       endTime: null,
       duration: 0,
       trackingLevel: sessionData.trackingLevel || 'comprehensive',
-      
+
       // Session-specific metrics
       interactions: [],
       tasks: [],
       errors: [],
       satisfactionEvents: [],
-      
+
       // Session context
       context: {
         language: get(selectedLanguage),
@@ -187,13 +185,13 @@ export class VoiceUXMetricsTracker {
         }
       }
     };
-    
+
     // Track session start
     this.trackEvent('session_started', {
       sessionId: sessionId,
       context: this.currentSession.context
     });
-    
+
     console.log('UX session started:', sessionId);
   }
 
@@ -207,36 +205,36 @@ export class VoiceUXMetricsTracker {
 
     const endTime = Date.now();
     const duration = endTime - this.currentSession.startTime;
-    
+
     this.currentSession.endTime = endTime;
     this.currentSession.duration = duration;
-    
+
     // Calculate session metrics
     const sessionMetrics = this.calculateSessionMetrics(this.currentSession);
-    
+
     // Track session end
     this.trackEvent('session_ended', {
       sessionId: this.currentSession.id,
       duration: duration,
       metrics: sessionMetrics
     });
-    
+
     // Add to session history
     this.sessionHistory.push({
       ...this.currentSession,
       metrics: sessionMetrics
     });
-    
+
     // Maintain session history size
     if (this.sessionHistory.length > this.maxSessionHistory) {
       this.sessionHistory.shift();
     }
-    
+
     // Update aggregated metrics
     this.updateAggregatedMetrics(sessionMetrics);
-    
+
     console.log('UX session ended:', this.currentSession.id, 'Duration:', duration);
-    
+
     this.currentSession = null;
   }
 
@@ -254,29 +252,29 @@ export class VoiceUXMetricsTracker {
       sessionId: this.currentSession.id,
       timestamp: Date.now(),
       type: interactionData.type || 'unknown',
-      
+
       // Interaction details
       action: interactionData.action || 'unknown',
       target: interactionData.target || null,
       input: interactionData.input || null,
       output: interactionData.output || null,
-      
+
       // Performance metrics
       startTime: interactionData.startTime || Date.now(),
       endTime: interactionData.endTime || Date.now(),
       duration: interactionData.duration || 0,
-      
+
       // Success metrics
       successful: interactionData.successful !== false,
       errorOccurred: interactionData.errorOccurred || false,
       errorType: interactionData.errorType || null,
       recoveryTime: interactionData.recoveryTime || 0,
-      
+
       // User experience metrics
       userSatisfaction: interactionData.userSatisfaction || null,
       cognitiveLoad: interactionData.cognitiveLoad || 'medium',
       frustrationLevel: interactionData.frustrationLevel || 'none',
-      
+
       // Context
       context: {
         voiceMode: get(isVoiceModeActive),
@@ -285,21 +283,21 @@ export class VoiceUXMetricsTracker {
         ...interactionData.context
       }
     };
-    
+
     // Add to current session
     this.currentSession.interactions.push(interaction);
-    
+
     // Add to interaction buffer
     this.interactionBuffer.push(interaction);
-    
+
     // Maintain buffer size
     if (this.interactionBuffer.length > this.maxInteractionBuffer) {
       this.interactionBuffer.shift();
     }
-    
+
     // Update real-time indicators
     this.updateRealTimeIndicators(interaction);
-    
+
     // Track with diagnostics system
     voiceDiagnostics.trackUserExperience({
       sessionId: this.currentSession.id,
@@ -309,8 +307,12 @@ export class VoiceUXMetricsTracker {
       userSatisfaction: interaction.userSatisfaction,
       errorEncountered: interaction.errorOccurred
     });
-    
-    console.log('Interaction tracked:', interaction.type, interaction.successful ? 'success' : 'failure');
+
+    console.log(
+      'Interaction tracked:',
+      interaction.type,
+      interaction.successful ? 'success' : 'failure'
+    );
   }
 
   /**
@@ -326,41 +328,41 @@ export class VoiceUXMetricsTracker {
       id: `task_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
       sessionId: this.currentSession.id,
       timestamp: Date.now(),
-      
+
       // Task details
       name: taskData.name || 'unnamed_task',
       description: taskData.description || '',
       category: taskData.category || 'general',
-      
+
       // Completion metrics
       status: taskData.status || 'completed', // 'completed', 'abandoned', 'failed'
       startTime: taskData.startTime || Date.now(),
       endTime: taskData.endTime || Date.now(),
       duration: taskData.duration || 0,
-      
+
       // Success metrics
       successful: taskData.successful !== false,
       completionRate: taskData.completionRate || (taskData.successful ? 1 : 0),
       errorCount: taskData.errorCount || 0,
       helpRequested: taskData.helpRequested || false,
-      
+
       // User experience
       difficultyRating: taskData.difficultyRating || null,
       satisfactionRating: taskData.satisfactionRating || null,
-      
+
       // Context
       context: {
         interactions: this.currentSession.interactions.length,
         ...taskData.context
       }
     };
-    
+
     // Add to current session
     this.currentSession.tasks.push(task);
-    
+
     // Update task completion metrics
     this.updateTaskMetrics(task);
-    
+
     console.log('Task tracked:', task.name, task.status);
   }
 
@@ -377,23 +379,23 @@ export class VoiceUXMetricsTracker {
       id: `error_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
       sessionId: this.currentSession.id,
       timestamp: Date.now(),
-      
+
       // Error details
       type: errorData.type || 'unknown',
       category: errorData.category || 'system',
       severity: errorData.severity || 'medium',
       message: errorData.message || '',
-      
+
       // Recovery metrics
       recoverable: errorData.recoverable !== false,
       recoveryTime: errorData.recoveryTime || 0,
       recoveryMethod: errorData.recoveryMethod || null,
       userAssistanceRequired: errorData.userAssistanceRequired || false,
-      
+
       // Impact metrics
       taskImpact: errorData.taskImpact || 'none', // 'none', 'delayed', 'failed', 'abandoned'
       userFrustration: errorData.userFrustration || 'low',
-      
+
       // Context
       context: {
         currentTask: this.getCurrentTask(),
@@ -401,16 +403,16 @@ export class VoiceUXMetricsTracker {
         ...errorData.context
       }
     };
-    
+
     // Add to current session
     this.currentSession.errors.push(error);
-    
+
     // Update error metrics
     this.updateErrorMetrics(error);
-    
+
     // Update real-time frustration indicator
     this.updateFrustrationLevel(error);
-    
+
     console.log('Error tracked:', error.type, error.severity);
   }
 
@@ -427,18 +429,18 @@ export class VoiceUXMetricsTracker {
       id: `feedback_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
       sessionId: this.currentSession.id,
       timestamp: Date.now(),
-      
+
       // Satisfaction ratings
       overallSatisfaction: feedbackData.overallSatisfaction || null,
       voiceQuality: feedbackData.voiceQuality || null,
       responsiveness: feedbackData.responsiveness || null,
       naturalness: feedbackData.naturalness || null,
       easeOfUse: feedbackData.easeOfUse || null,
-      
+
       // Qualitative feedback
       comments: feedbackData.comments || '',
       suggestions: feedbackData.suggestions || '',
-      
+
       // Context
       context: {
         triggerEvent: feedbackData.triggerEvent || 'manual',
@@ -446,13 +448,13 @@ export class VoiceUXMetricsTracker {
         interactionCount: this.currentSession.interactions.length
       }
     };
-    
+
     // Add to current session
     this.currentSession.satisfactionEvents.push(feedback);
-    
+
     // Update satisfaction metrics
     this.updateSatisfactionMetrics(feedback);
-    
+
     console.log('Satisfaction feedback tracked:', feedback.overallSatisfaction);
   }
 
@@ -463,7 +465,7 @@ export class VoiceUXMetricsTracker {
   trackFeatureUsage(featureData) {
     const feature = featureData.feature || 'unknown';
     const action = featureData.action || 'used';
-    
+
     // Update feature usage metrics
     if (!this.uxMetrics.engagement.featureUsage[feature]) {
       this.uxMetrics.engagement.featureUsage[feature] = {
@@ -473,20 +475,20 @@ export class VoiceUXMetricsTracker {
         userSatisfaction: 0
       };
     }
-    
+
     const featureMetrics = this.uxMetrics.engagement.featureUsage[feature];
     featureMetrics.usageCount++;
     featureMetrics.lastUsed = Date.now();
-    
+
     if (featureData.satisfaction) {
       if (featureMetrics.userSatisfaction === 0) {
         featureMetrics.userSatisfaction = featureData.satisfaction;
       } else {
-        featureMetrics.userSatisfaction = 
+        featureMetrics.userSatisfaction =
           (featureMetrics.userSatisfaction + featureData.satisfaction) / 2;
       }
     }
-    
+
     console.log('Feature usage tracked:', feature, action);
   }
 
@@ -499,30 +501,33 @@ export class VoiceUXMetricsTracker {
     const interactions = session.interactions || [];
     const tasks = session.tasks || [];
     const errors = session.errors || [];
-    
+
     // Effectiveness metrics
-    const completedTasks = tasks.filter(t => t.status === 'completed').length;
+    const completedTasks = tasks.filter((t) => t.status === 'completed').length;
     const taskCompletionRate = tasks.length > 0 ? completedTasks / tasks.length : 0;
-    
+
     // Efficiency metrics
-    const successfulInteractions = interactions.filter(i => i.successful).length;
-    const interactionSuccessRate = interactions.length > 0 ? successfulInteractions / interactions.length : 0;
-    const averageInteractionTime = interactions.length > 0 
-      ? interactions.reduce((sum, i) => sum + i.duration, 0) / interactions.length 
-      : 0;
-    
+    const successfulInteractions = interactions.filter((i) => i.successful).length;
+    const interactionSuccessRate =
+      interactions.length > 0 ? successfulInteractions / interactions.length : 0;
+    const averageInteractionTime =
+      interactions.length > 0
+        ? interactions.reduce((sum, i) => sum + i.duration, 0) / interactions.length
+        : 0;
+
     // Error metrics
     const errorRate = interactions.length > 0 ? errors.length / interactions.length : 0;
-    const averageRecoveryTime = errors.length > 0
-      ? errors.reduce((sum, e) => sum + e.recoveryTime, 0) / errors.length
-      : 0;
-    
+    const averageRecoveryTime =
+      errors.length > 0 ? errors.reduce((sum, e) => sum + e.recoveryTime, 0) / errors.length : 0;
+
     // Satisfaction metrics
     const satisfactionEvents = session.satisfactionEvents || [];
-    const averageSatisfaction = satisfactionEvents.length > 0
-      ? satisfactionEvents.reduce((sum, s) => sum + (s.overallSatisfaction || 0), 0) / satisfactionEvents.length
-      : 0;
-    
+    const averageSatisfaction =
+      satisfactionEvents.length > 0
+        ? satisfactionEvents.reduce((sum, s) => sum + (s.overallSatisfaction || 0), 0) /
+          satisfactionEvents.length
+        : 0;
+
     return {
       effectiveness: {
         taskCompletionRate: taskCompletionRate,
@@ -558,22 +563,25 @@ export class VoiceUXMetricsTracker {
     // Update task completion metrics
     this.uxMetrics.taskCompletion.totalTasks += sessionMetrics.effectiveness.totalTasks;
     this.uxMetrics.taskCompletion.completedTasks += sessionMetrics.effectiveness.completedTasks;
-    
+
     // Update interaction metrics
     this.uxMetrics.interaction.totalInteractions += sessionMetrics.efficiency.totalInteractions;
-    this.uxMetrics.interaction.successfulInteractions += 
-      Math.round(sessionMetrics.efficiency.totalInteractions * sessionMetrics.efficiency.interactionSuccessRate);
-    
+    this.uxMetrics.interaction.successfulInteractions += Math.round(
+      sessionMetrics.efficiency.totalInteractions * sessionMetrics.efficiency.interactionSuccessRate
+    );
+
     // Update satisfaction metrics
     if (sessionMetrics.satisfaction.averageSatisfaction > 0) {
-      this.uxMetrics.satisfaction.overallScore = 
-        (this.uxMetrics.satisfaction.overallScore + sessionMetrics.satisfaction.averageSatisfaction) / 2;
+      this.uxMetrics.satisfaction.overallScore =
+        (this.uxMetrics.satisfaction.overallScore +
+          sessionMetrics.satisfaction.averageSatisfaction) /
+        2;
     }
-    
+
     // Update error metrics
-    this.uxMetrics.interaction.errorRate = 
+    this.uxMetrics.interaction.errorRate =
       (this.uxMetrics.interaction.errorRate + sessionMetrics.errors.errorRate) / 2;
-    
+
     // Recalculate derived metrics
     this.recalculateDerivedMetrics();
   }
@@ -584,23 +592,24 @@ export class VoiceUXMetricsTracker {
   recalculateDerivedMetrics() {
     // Task completion rate
     if (this.uxMetrics.taskCompletion.totalTasks > 0) {
-      this.uxMetrics.taskCompletion.completionRate = 
+      this.uxMetrics.taskCompletion.completionRate =
         this.uxMetrics.taskCompletion.completedTasks / this.uxMetrics.taskCompletion.totalTasks;
     }
-    
+
     // Interaction success rate
     if (this.uxMetrics.interaction.totalInteractions > 0) {
-      this.uxMetrics.interaction.successRate = 
-        this.uxMetrics.interaction.successfulInteractions / this.uxMetrics.interaction.totalInteractions;
+      this.uxMetrics.interaction.successRate =
+        this.uxMetrics.interaction.successfulInteractions /
+        this.uxMetrics.interaction.totalInteractions;
     }
-    
+
     // Overall usability score (composite metric)
     const taskScore = this.uxMetrics.taskCompletion.completionRate || 0;
     const interactionScore = this.uxMetrics.interaction.successRate || 0;
     const satisfactionScore = this.uxMetrics.satisfaction.overallScore / 5; // Normalize to 0-1
     const errorPenalty = Math.min(this.uxMetrics.interaction.errorRate, 0.5); // Cap at 50%
-    
-    this.uxMetrics.usability.overallScore = 
+
+    this.uxMetrics.usability.overallScore =
       (taskScore * 0.3 + interactionScore * 0.3 + satisfactionScore * 0.4) * (1 - errorPenalty);
   }
 
@@ -609,26 +618,35 @@ export class VoiceUXMetricsTracker {
    * @param {Object} interaction - Recent interaction
    */
   updateRealTimeIndicators(interaction) {
+    if (!interaction) {
+      this.realTimeIndicators.interactionSuccess = false;
+      this.realTimeIndicators.cognitiveLoad = 'low';
+      this.realTimeIndicators.currentSatisfaction = 1;
+      this.realTimeIndicators.engagementLevel = 'low';
+      return;
+    }
+
     // Update interaction success indicator
-    this.realTimeIndicators.interactionSuccess = interaction.successful;
-    
+    this.realTimeIndicators.interactionSuccess = Boolean(interaction.successful);
+
     // Update cognitive load based on interaction duration and errors
-    if (interaction.duration > 5000 || interaction.errorOccurred) {
+    if ((interaction.duration ?? 0) > 5000 || interaction.errorOccurred) {
       this.realTimeIndicators.cognitiveLoad = 'high';
-    } else if (interaction.duration > 2000) {
+    } else if ((interaction.duration ?? 0) > 2000) {
       this.realTimeIndicators.cognitiveLoad = 'medium';
     } else {
       this.realTimeIndicators.cognitiveLoad = 'low';
     }
-    
+
     // Update satisfaction based on recent interactions
     const recentInteractions = this.getRecentInteractions(5);
-    const recentSuccessRate = recentInteractions.length > 0
-      ? recentInteractions.filter(i => i.successful).length / recentInteractions.length
-      : 1;
-    
+    const recentSuccessRate =
+      recentInteractions.length > 0
+        ? recentInteractions.filter((i) => i.successful).length / recentInteractions.length
+        : 1;
+
     this.realTimeIndicators.currentSatisfaction = recentSuccessRate;
-    
+
     // Update engagement level
     const interactionFrequency = this.calculateRecentInteractionFrequency();
     if (interactionFrequency > 2) {
@@ -647,16 +665,39 @@ export class VoiceUXMetricsTracker {
   updateFrustrationLevel(error) {
     const recentErrors = this.getRecentErrors(5);
     const errorFrequency = recentErrors.length;
-    
-    if (errorFrequency >= 3) {
-      this.realTimeIndicators.userFrustration = 'high';
-    } else if (errorFrequency >= 2) {
-      this.realTimeIndicators.userFrustration = 'medium';
-    } else if (errorFrequency >= 1) {
-      this.realTimeIndicators.userFrustration = 'low';
-    } else {
-      this.realTimeIndicators.userFrustration = 'none';
-    }
+
+    const severityOrder = ['none', 'low', 'medium', 'high'];
+    const severityFromError = (() => {
+      if (!error) return 'none';
+      if (typeof error.userFrustration === 'string') {
+        return error.userFrustration;
+      }
+
+      switch (error.severity) {
+        case 'critical':
+        case 'high':
+          return 'high';
+        case 'medium':
+          return 'medium';
+        case 'low':
+          return 'low';
+        default:
+          return 'none';
+      }
+    })();
+
+    const frequencyLevel = (() => {
+      if (errorFrequency >= 3) return 'high';
+      if (errorFrequency >= 2) return 'medium';
+      if (errorFrequency >= 1) return 'low';
+      return 'none';
+    })();
+
+    const severityIndex = severityOrder.indexOf(severityFromError);
+    const frequencyIndex = severityOrder.indexOf(frequencyLevel);
+    const resolvedLevel = severityIndex > frequencyIndex ? severityFromError : frequencyLevel;
+
+    this.realTimeIndicators.userFrustration = resolvedLevel;
   }
 
   /**
@@ -665,6 +706,10 @@ export class VoiceUXMetricsTracker {
    * @returns {Array} Recent interactions
    */
   getRecentInteractions(count = 5) {
+    if (!Array.isArray(this.interactionBuffer) || this.interactionBuffer.length === 0) {
+      return [];
+    }
+
     return this.interactionBuffer.slice(-count);
   }
 
@@ -674,7 +719,14 @@ export class VoiceUXMetricsTracker {
    * @returns {Array} Recent errors
    */
   getRecentErrors(count = 5) {
-    if (!this.currentSession) return [];
+    if (
+      !this.currentSession ||
+      !Array.isArray(this.currentSession.errors) ||
+      this.currentSession.errors.length === 0
+    ) {
+      return [];
+    }
+
     return this.currentSession.errors.slice(-count);
   }
 
@@ -685,12 +737,12 @@ export class VoiceUXMetricsTracker {
   calculateRecentInteractionFrequency() {
     const recentInteractions = this.getRecentInteractions(10);
     if (recentInteractions.length < 2) return 0;
-    
-    const timeSpan = recentInteractions[recentInteractions.length - 1].timestamp - 
-                   recentInteractions[0].timestamp;
-    
+
+    const timeSpan =
+      recentInteractions[recentInteractions.length - 1].timestamp - recentInteractions[0].timestamp;
+
     if (timeSpan <= 0) return 0; // Avoid division by zero or negative values
-    
+
     return (recentInteractions.length / timeSpan) * 60000; // per minute
   }
 
@@ -702,9 +754,9 @@ export class VoiceUXMetricsTracker {
     if (!this.currentSession || this.currentSession.tasks.length === 0) {
       return null;
     }
-    
+
     // Return the most recent task that's not completed
-    const incompleteTasks = this.currentSession.tasks.filter(t => t.status !== 'completed');
+    const incompleteTasks = this.currentSession.tasks.filter((t) => t.status !== 'completed');
     return incompleteTasks[incompleteTasks.length - 1] || null;
   }
 
@@ -718,16 +770,16 @@ export class VoiceUXMetricsTracker {
     } else if (task.status === 'abandoned') {
       this.uxMetrics.taskCompletion.abandonedTasks++;
     }
-    
+
     this.uxMetrics.taskCompletion.totalTasks++;
-    
+
     // Update average completion time
     if (task.successful && task.duration > 0) {
       const currentAvg = this.uxMetrics.taskCompletion.averageCompletionTime;
       const completedCount = this.uxMetrics.taskCompletion.completedTasks;
-      
-      this.uxMetrics.taskCompletion.averageCompletionTime = 
-        ((currentAvg * (completedCount - 1)) + task.duration) / completedCount;
+
+      this.uxMetrics.taskCompletion.averageCompletionTime =
+        (currentAvg * (completedCount - 1) + task.duration) / completedCount;
     }
   }
 
@@ -739,8 +791,7 @@ export class VoiceUXMetricsTracker {
     // Update recovery time
     if (error.recoveryTime > 0) {
       const currentAvg = this.uxMetrics.interaction.recoveryTime;
-      this.uxMetrics.interaction.recoveryTime = 
-        (currentAvg + error.recoveryTime) / 2;
+      this.uxMetrics.interaction.recoveryTime = (currentAvg + error.recoveryTime) / 2;
     }
   }
 
@@ -754,44 +805,44 @@ export class VoiceUXMetricsTracker {
       if (this.uxMetrics.satisfaction.overallScore === 0) {
         this.uxMetrics.satisfaction.overallScore = feedback.overallSatisfaction;
       } else {
-        this.uxMetrics.satisfaction.overallScore = 
+        this.uxMetrics.satisfaction.overallScore =
           (this.uxMetrics.satisfaction.overallScore + feedback.overallSatisfaction) / 2;
       }
     }
-    
+
     if (feedback.voiceQuality) {
       if (this.uxMetrics.satisfaction.voiceQualityScore === 0) {
         this.uxMetrics.satisfaction.voiceQualityScore = feedback.voiceQuality;
       } else {
-        this.uxMetrics.satisfaction.voiceQualityScore = 
+        this.uxMetrics.satisfaction.voiceQualityScore =
           (this.uxMetrics.satisfaction.voiceQualityScore + feedback.voiceQuality) / 2;
       }
     }
-    
+
     if (feedback.responsiveness) {
       if (this.uxMetrics.satisfaction.responsivenessScore === 0) {
         this.uxMetrics.satisfaction.responsivenessScore = feedback.responsiveness;
       } else {
-        this.uxMetrics.satisfaction.responsivenessScore = 
+        this.uxMetrics.satisfaction.responsivenessScore =
           (this.uxMetrics.satisfaction.responsivenessScore + feedback.responsiveness) / 2;
       }
     }
-    
+
     if (feedback.naturalness) {
       if (this.uxMetrics.satisfaction.naturalness === 0) {
         this.uxMetrics.satisfaction.naturalness = feedback.naturalness;
       } else {
-        this.uxMetrics.satisfaction.naturalness = 
+        this.uxMetrics.satisfaction.naturalness =
           (this.uxMetrics.satisfaction.naturalness + feedback.naturalness) / 2;
       }
     }
-    
+
     // Store feedback
     this.uxMetrics.satisfaction.userFeedback.push({
       timestamp: Date.now(),
       feedback: feedback
     });
-    
+
     // Maintain feedback history
     if (this.uxMetrics.satisfaction.userFeedback.length > 100) {
       this.uxMetrics.satisfaction.userFeedback.shift();
@@ -844,10 +895,10 @@ export class VoiceUXMetricsTracker {
 
     // Update engagement metrics
     this.updateEngagementMetrics();
-    
+
     // Check for drop-off points
     this.checkForDropOffPoints();
-    
+
     // Update real-time indicators
     this.updateRealTimeIndicators();
   }
@@ -857,13 +908,12 @@ export class VoiceUXMetricsTracker {
    */
   updateEngagementMetrics() {
     if (!this.currentSession) return;
-    
+
     const sessionDuration = Date.now() - this.currentSession.startTime;
     const interactionCount = this.currentSession.interactions.length;
-    
+
     this.uxMetrics.engagement.sessionDuration = sessionDuration;
-    this.uxMetrics.engagement.interactionFrequency = 
-      interactionCount / (sessionDuration / 60000); // per minute
+    this.uxMetrics.engagement.interactionFrequency = interactionCount / (sessionDuration / 60000); // per minute
   }
 
   /**
@@ -872,10 +922,11 @@ export class VoiceUXMetricsTracker {
   checkForDropOffPoints() {
     // Identify potential drop-off points based on user behavior
     const recentInteractions = this.getRecentInteractions(5);
-    const timeSinceLastInteraction = Date.now() - 
-      (recentInteractions[recentInteractions.length - 1]?.timestamp || Date.now());
-    
-    if (timeSinceLastInteraction > 60000) { // 1 minute of inactivity
+    const timeSinceLastInteraction =
+      Date.now() - (recentInteractions[recentInteractions.length - 1]?.timestamp || Date.now());
+
+    if (timeSinceLastInteraction > 60000) {
+      // 1 minute of inactivity
       this.uxMetrics.engagement.dropOffPoints.push({
         timestamp: Date.now(),
         inactivityDuration: timeSinceLastInteraction,
@@ -893,13 +944,22 @@ export class VoiceUXMetricsTracker {
    * @param {Object} eventData - Event data
    */
   trackEvent(eventType, eventData) {
-    const event = {
-      type: eventType,
-      timestamp: Date.now(),
-      sessionId: this.currentSession?.id || null,
-      data: eventData
-    };
-    
+    const timestamp = Date.now();
+    const sessionId = this.currentSession?.id || null;
+
+    if (this.isTracking && this.currentSession) {
+      if (!Array.isArray(this.currentSession.events)) {
+        this.currentSession.events = [];
+      }
+
+      this.currentSession.events.push({
+        type: eventType,
+        timestamp,
+        sessionId,
+        data: eventData
+      });
+    }
+
     console.log('UX event tracked:', eventType, eventData);
   }
 
@@ -928,26 +988,26 @@ export class VoiceUXMetricsTracker {
       includeInteractionDetails = false,
       format = 'json'
     } = options;
-    
+
     const exportData = {
       exportTimestamp: Date.now(),
       trackerId: this.trackerId,
       uxMetrics: this.uxMetrics,
       realTimeIndicators: this.realTimeIndicators
     };
-    
+
     if (includeSessionHistory) {
       exportData.sessionHistory = this.sessionHistory;
     }
-    
+
     if (includeInteractionDetails) {
       exportData.interactionBuffer = this.interactionBuffer;
     }
-    
+
     if (format === 'csv') {
       return this.convertUXToCSV(exportData);
     }
-    
+
     return exportData;
   }
 
@@ -959,23 +1019,17 @@ export class VoiceUXMetricsTracker {
   convertUXToCSV(exportData) {
     const headers = ['timestamp', 'metric_category', 'metric_name', 'value', 'unit'];
     const rows = [];
-    
+
     // Add UX metrics
     Object.entries(exportData.uxMetrics).forEach(([category, metrics]) => {
       Object.entries(metrics).forEach(([metric, value]) => {
         if (typeof value === 'number') {
-          rows.push([
-            exportData.exportTimestamp,
-            category,
-            metric,
-            value,
-            'score'
-          ]);
+          rows.push([exportData.exportTimestamp, category, metric, value, 'score']);
         }
       });
     });
-    
-    return [headers, ...rows].map(row => row.join(',')).join('\n');
+
+    return [headers, ...rows].map((row) => row.join(',')).join('\n');
   }
 
   /**
@@ -1018,10 +1072,10 @@ export class VoiceUXMetricsTracker {
         dropOffPoints: []
       }
     };
-    
+
     this.sessionHistory = [];
     this.interactionBuffer = [];
-    
+
     console.log('UX metrics reset');
   }
 

--- a/src/lib/modules/navigation/components/Navigation.svelte
+++ b/src/lib/modules/navigation/components/Navigation.svelte
@@ -60,6 +60,12 @@
           >
             Finance
           </a>
+          <a
+            href="/admin/voice-analytics"
+            class="dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700 transition-colors"
+          >
+            Voice Analytics
+          </a>
         {/if}
         <ThemeToggle />
         <AuthButton />
@@ -138,6 +144,15 @@
             }}
           >
             Finance
+          </a>
+          <a
+            href="/admin/voice-analytics"
+            class="block px-3 py-2 dark:text-gray-300 dark:hover:text-amber-400 text-stone-600 hover:text-amber-700"
+            on:click={() => {
+              mobileMenuOpen = false;
+            }}
+          >
+            Voice Analytics
           </a>
         {/if}
         <div class="px-3 py-2">

--- a/src/routes/admin/voice-analytics/+page.server.js
+++ b/src/routes/admin/voice-analytics/+page.server.js
@@ -1,0 +1,27 @@
+import { redirect } from '@sveltejs/kit';
+import { STORAGE_KEYS } from '$shared/utils/constants';
+
+/**
+ * Server-side load for the admin voice analytics page.
+ * Ensures only admins can access the analytics dashboard.
+ */
+export const load = async ({ locals, cookies, url }) => {
+  let user = locals.user;
+
+  if (!user) {
+    const cookieUser = cookies.get(STORAGE_KEYS.USER);
+    if (cookieUser) {
+      try {
+        user = JSON.parse(cookieUser);
+      } catch (error) {
+        console.error('Failed to parse user cookie during voice analytics load', error);
+      }
+    }
+  }
+
+  if (!user || user.role !== 'admin') {
+    throw redirect(303, `/login?redirect=${url.pathname}`);
+  }
+
+  return { user };
+};

--- a/src/routes/admin/voice-analytics/+page.svelte
+++ b/src/routes/admin/voice-analytics/+page.svelte
@@ -1,0 +1,286 @@
+<script>
+  import { onMount, onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
+  import { get } from 'svelte/store';
+  import { voiceAnalyticsStore } from '$modules/admin/voice-analytics/voiceAnalyticsStore.js';
+  import HealthStatusPanel from '$modules/admin/voice-analytics/components/HealthStatusPanel.svelte';
+  import PerformanceAnalyticsPanel from '$modules/admin/voice-analytics/components/PerformanceAnalyticsPanel.svelte';
+  import UXMetricsPanel from '$modules/admin/voice-analytics/components/UXMetricsPanel.svelte';
+  import DiagnosticReportingPanel from '$modules/admin/voice-analytics/components/DiagnosticReportingPanel.svelte';
+
+  export let data;
+
+  let notification = '';
+  let notificationType = 'success';
+  let notificationTimeout;
+  let lastReportTimestamp = null;
+
+  const showNotification = (message, type = 'success') => {
+    notification = message;
+    notificationType = type;
+
+    if (notificationTimeout) {
+      clearTimeout(notificationTimeout);
+    }
+
+    notificationTimeout = setTimeout(() => {
+      notification = '';
+    }, 4000);
+  };
+
+  const downloadFile = (payload, filename, mimeType) => {
+    if (!browser || !payload) return;
+
+    const serialized = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
+    const dataBlob = new Blob([serialized], { type: mimeType });
+
+    const objectUrl = URL.createObjectURL(dataBlob);
+    const anchor = document.createElement('a');
+    anchor.href = objectUrl;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(objectUrl);
+  };
+
+  const handleHealthCheck = async () => {
+    try {
+      await voiceAnalyticsStore.runHealthCheck();
+      showNotification('Health check completed successfully.');
+    } catch (error) {
+      showNotification('Health check failed. Check console for details.', 'error');
+    }
+  };
+
+  const handleThresholdUpdate = (event) => {
+    const success = voiceAnalyticsStore.updateThresholds(event.detail.thresholds);
+    if (success) {
+      showNotification('Performance thresholds updated.');
+    } else {
+      showNotification('Failed to update performance thresholds.', 'error');
+    }
+  };
+
+  const handlePerformanceExport = (event) => {
+    const format = event.detail.format;
+    const exported = voiceAnalyticsStore.exportPerformanceData({ format });
+
+    if (!exported) {
+      showNotification('Failed to export performance data.', 'error');
+      return;
+    }
+
+    if (format === 'csv') {
+      downloadFile(exported, 'voice-performance.csv', 'text/csv');
+    } else {
+      downloadFile(JSON.stringify(exported, null, 2), 'voice-performance.json', 'application/json');
+    }
+    showNotification('Performance data exported.');
+  };
+
+  const handleUXExport = (event) => {
+    const format = event.detail.format;
+    const exported = voiceAnalyticsStore.exportUXData({ format });
+
+    if (!exported) {
+      showNotification('Failed to export UX data.', 'error');
+      return;
+    }
+
+    if (format === 'csv') {
+      downloadFile(exported, 'voice-ux-metrics.csv', 'text/csv');
+    } else {
+      downloadFile(JSON.stringify(exported, null, 2), 'voice-ux-metrics.json', 'application/json');
+    }
+    showNotification('UX data exported.');
+  };
+
+  const handleDiagnosticsExport = (event) => {
+    const format = event.detail.format;
+    const exported = voiceAnalyticsStore.exportDiagnostics({ format, includeRawMetrics: true });
+
+    if (!exported) {
+      showNotification('Failed to export diagnostic data.', 'error');
+      return;
+    }
+
+    if (format === 'csv') {
+      downloadFile(exported, 'voice-diagnostics.csv', 'text/csv');
+    } else {
+      downloadFile(JSON.stringify(exported, null, 2), 'voice-diagnostics.json', 'application/json');
+    }
+    showNotification('Diagnostic data exported.');
+  };
+
+  const handleCombinedExport = (event) => {
+    const format = event.detail.format;
+    const currentState = get(voiceAnalyticsStore);
+    const combined = {
+      generatedAt: Date.now(),
+      systemHealth: currentState.systemHealth,
+      performance: currentState.performance,
+      ux: currentState.ux
+    };
+
+    if (format === 'csv') {
+      const csv = voiceAnalyticsStore.exportDiagnostics({ format: 'csv', includeRawMetrics: true });
+      if (!csv) {
+        showNotification('Failed to export combined data.', 'error');
+        return;
+      }
+      downloadFile(csv, 'voice-analytics-combined.csv', 'text/csv');
+    } else {
+      downloadFile(
+        JSON.stringify(combined, null, 2),
+        'voice-analytics-combined.json',
+        'application/json'
+      );
+    }
+    showNotification('Combined analytics exported.');
+  };
+
+  const handleGenerateReport = async () => {
+    try {
+      const combinedReport = await voiceAnalyticsStore.generateCombinedReport();
+      if (!combinedReport) {
+        showNotification('Report generation did not return data.', 'error');
+        return;
+      }
+      lastReportTimestamp = combinedReport.timestamp ?? Date.now();
+      downloadFile(
+        JSON.stringify(combinedReport, null, 2),
+        `voice-diagnostic-report-${new Date(lastReportTimestamp).toISOString()}.json`,
+        'application/json'
+      );
+      showNotification('Diagnostic report generated and downloaded.');
+    } catch (error) {
+      showNotification('Failed to generate diagnostic report.', 'error');
+    }
+  };
+
+  const handleCopyIssues = async () => {
+    const { systemHealth } = get(voiceAnalyticsStore);
+    const issues = systemHealth?.issues ?? [];
+    if (!browser) return;
+
+    try {
+      await navigator.clipboard.writeText(
+        issues.length ? issues.join('\n') : 'No outstanding issues.'
+      );
+      showNotification('Issues copied to clipboard.');
+    } catch (error) {
+      console.error('Failed to copy issues to clipboard', error);
+      showNotification('Unable to copy issues to clipboard.', 'error');
+    }
+  };
+
+  const handleToggleTracking = async (event) => {
+    const enabled = event.detail.enabled;
+    const success = await voiceAnalyticsStore.toggleUXTracking(enabled);
+    if (success) {
+      showNotification(enabled ? 'Live UX tracking enabled.' : 'Live UX tracking disabled.');
+    } else {
+      showNotification('Unable to toggle UX tracking. Check logs for details.', 'error');
+    }
+  };
+
+  onMount(() => {
+    voiceAnalyticsStore.init();
+
+    return () => {
+      if (notificationTimeout) {
+        clearTimeout(notificationTimeout);
+      }
+      voiceAnalyticsStore.teardown();
+    };
+  });
+
+  onDestroy(() => {
+    if (notificationTimeout) {
+      clearTimeout(notificationTimeout);
+    }
+  });
+</script>
+
+<svelte:head>
+  <title>Admin • Voice Analytics</title>
+</svelte:head>
+
+<main class="max-w-7xl mx-auto px-6 py-10 space-y-8">
+  <header class="space-y-3">
+    <p class="text-sm text-stone-500 dark:text-gray-400">Administrator dashboard</p>
+    <h1 class="text-3xl font-bold text-stone-900 dark:text-white">Voice Analytics</h1>
+    <p class="text-stone-600 dark:text-gray-300 max-w-3xl">
+      Monitor system health, performance, and user experience in real time. Generate diagnostic
+      reports to keep the voice stack running smoothly.
+    </p>
+  </header>
+
+  {#if notification}
+    <div
+      class={`rounded-lg border px-4 py-3 text-sm shadow-sm ${
+        notificationType === 'error'
+          ? 'border-red-200 bg-red-50 text-red-700 dark:border-red-800/60 dark:bg-red-900/40 dark:text-red-200'
+          : 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-900/30 dark:text-emerald-200'
+      }`}
+    >
+      {notification}
+    </div>
+  {/if}
+
+  {#if data?.user}
+    <p class="text-sm text-stone-500 dark:text-gray-400">
+      Signed in as <span class="font-medium">{data.user.email}</span>
+    </p>
+  {/if}
+
+  {#if $voiceAnalyticsStore}
+    <div class="space-y-8">
+      <HealthStatusPanel
+        systemHealth={$voiceAnalyticsStore.systemHealth}
+        lastHealthCheck={$voiceAnalyticsStore.systemHealth?.lastHealthCheck}
+        monitoringActive={$voiceAnalyticsStore.monitoring.diagnostics}
+        runningHealthCheck={$voiceAnalyticsStore.ui.healthCheckRunning}
+        errorMessage={$voiceAnalyticsStore.errors?.diagnostics}
+        on:runHealthCheck={handleHealthCheck}
+      />
+
+      <PerformanceAnalyticsPanel
+        performance={$voiceAnalyticsStore.performance}
+        monitoringActive={$voiceAnalyticsStore.monitoring.performance}
+        lastUpdated={$voiceAnalyticsStore.lastUpdated}
+        errorMessage={$voiceAnalyticsStore.errors?.performance}
+        on:updateThresholds={handleThresholdUpdate}
+        on:export={handlePerformanceExport}
+      />
+
+      <UXMetricsPanel
+        ux={$voiceAnalyticsStore.ux}
+        lastUpdated={$voiceAnalyticsStore.lastUpdated}
+        errorMessage={$voiceAnalyticsStore.errors?.ux}
+        on:toggleTracking={handleToggleTracking}
+        on:export={handleUXExport}
+      />
+
+      <DiagnosticReportingPanel
+        systemHealth={$voiceAnalyticsStore.systemHealth}
+        performanceAnalysis={$voiceAnalyticsStore.performance.analysis}
+        uxSnapshot={{
+          metrics: $voiceAnalyticsStore.ux.metrics,
+          sessionHistory: $voiceAnalyticsStore.ux.sessionHistory,
+          realTimeIndicators: $voiceAnalyticsStore.ux.realTimeIndicators
+        }}
+        generatingReport={$voiceAnalyticsStore.ui.generatingReport}
+        lastGeneratedAt={lastReportTimestamp}
+        errorMessage={$voiceAnalyticsStore.errors?.diagnostics}
+        on:generate={handleGenerateReport}
+        on:copyIssues={handleCopyIssues}
+        on:exportDiagnostics={handleDiagnosticsExport}
+        on:export={handleCombinedExport}
+      />
+    </div>
+  {:else}
+    <p class="text-sm text-stone-500 dark:text-gray-400">Loading analytics…</p>
+  {/if}
+</main>


### PR DESCRIPTION
## Summary
- guard audio buffer statistics against missing metadata and support metadata-driven fade configuration
- harden UX real-time indicators to tolerate absent interactions and derive frustration from severity and frequency
- persist tracked UX events in the active session while keeping history helpers resilient

## Testing
- npm run lint
- npx eslint src/lib/modules/chat/AudioBufferManager.js src/lib/modules/chat/VoiceUXMetricsTracker.js

------
https://chatgpt.com/codex/tasks/task_e_68d976f0bbec8324a1ea1e0ad2772c1e