### PR TITLE
fix: register llm provider manager on client

### DIFF
--- a/src/lib/modules/chat/components/ChatInterface.svelte
+++ b/src/lib/modules/chat/components/ChatInterface.svelte
@@ -20,6 +20,7 @@
   import { setVoiceModeActive } from '../voiceServices';
   import { container } from '$lib/shared/di/container';
   import { LLM_FEATURES } from '$lib/config/llm';
+  import { ensureProviderManager } from '$modules/llm/ensureProviderManager.js';
   import { OPENAI_CONFIG } from '$lib/config/api';
   import LanguageSelector from '$modules/i18n/components/LanguageSelector.svelte';
   import MessageList from './MessageList.svelte';
@@ -45,7 +46,7 @@
   onMount(async () => {
     if (LLM_FEATURES.ENABLE_PROVIDER_SWITCHING && browser) {
       try {
-        const providerManager = container.resolve('llmProviderManager');
+        const providerManager = await ensureProviderManager();
         availableProviders = providerManager.listProviders();
         selectedProvider = providerManager.defaultProvider;
         console.log('Available LLM providers:', availableProviders);

--- a/src/lib/modules/chat/components/EnhancedChatInterface.svelte
+++ b/src/lib/modules/chat/components/EnhancedChatInterface.svelte
@@ -20,6 +20,7 @@
   import { setVoiceModeActive } from '../voiceServices';
   import { container } from '$lib/shared/di/container';
   import { LLM_FEATURES } from '$lib/config/llm';
+  import { ensureProviderManager } from '$modules/llm/ensureProviderManager.js';
 
   import LanguageSelector from '$modules/i18n/components/LanguageSelector.svelte';
   import MessageList from './MessageList.svelte';
@@ -51,7 +52,7 @@
   onMount(async () => {
     if (LLM_FEATURES.ENABLE_PROVIDER_SWITCHING && browser) {
       try {
-        const providerManager = container.resolve('llmProviderManager');
+        const providerManager = await ensureProviderManager();
         availableProviders = providerManager.listProviders();
         selectedProvider = providerManager.defaultProvider;
         console.log('Available LLM providers:', availableProviders);

--- a/src/lib/modules/chat/components/MultiAgentChatInterface.svelte
+++ b/src/lib/modules/chat/components/MultiAgentChatInterface.svelte
@@ -20,6 +20,7 @@
   import { setVoiceModeActive } from '../voiceServices';
   import { container } from '$lib/shared/di/container';
   import { LLM_FEATURES } from '$lib/config/llm';
+  import { ensureProviderManager } from '$modules/llm/ensureProviderManager.js';
   import { OPENAI_CONFIG } from '$lib/config/api';
   import LanguageSelector from '$modules/i18n/components/LanguageSelector.svelte';
   import MessageList from './MessageList.svelte';
@@ -61,7 +62,7 @@
   onMount(async () => {
     if (LLM_FEATURES.ENABLE_PROVIDER_SWITCHING && browser) {
       try {
-        const providerManager = container.resolve('llmProviderManager');
+        const providerManager = await ensureProviderManager();
         availableProviders = providerManager.listProviders();
         selectedProvider = providerManager.defaultProvider;
         console.log('Available LLM providers:', availableProviders);

--- a/src/lib/modules/llm/ensureProviderManager.js
+++ b/src/lib/modules/llm/ensureProviderManager.js
@@ -1,0 +1,18 @@
+import { container } from '$lib/shared/di/container';
+
+let initializationPromise = null;
+
+export async function ensureProviderManager() {
+  if (container.has('llmProviderManager')) {
+    return container.resolve('llmProviderManager');
+  }
+
+  if (!initializationPromise) {
+    initializationPromise = import('./index.js').then(({ initializeLLMModule }) => {
+      const { providerManager } = initializeLLMModule();
+      return providerManager;
+    });
+  }
+
+  return initializationPromise;
+}


### PR DESCRIPTION
## Summary
- lazily initialize the LLM provider manager on the client when needed
- update chat interfaces to use the ensured provider manager before accessing providers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9b0ceabd4832484cb2b34ee8b5dcb