### PR TITLE
feat: add AI-assisted drafting for courses and agents

### DIFF
--- a/src/lib/modules/courses/components/AgentAIDraftPanel.svelte
+++ b/src/lib/modules/courses/components/AgentAIDraftPanel.svelte
@@ -1,0 +1,369 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import Button from '$shared/components/Button.svelte';
+  import { Bot, Sparkles, RefreshCw, X, AlertTriangle } from 'lucide-svelte';
+
+  export let open = false;
+  export let courseName = '';
+  export let languageHint = '';
+  export let levelHint = '';
+  export let prefetchedAgents = [];
+  export let allowOpenAI = true;
+
+  const dispatch = createEventDispatcher();
+
+  let form = {
+    roleFocus: '',
+    interactionStyle: '',
+    additionalNotes: ''
+  };
+  let loading = false;
+  let error = null;
+  let usage = null;
+  let agentSuggestions = [];
+  let confirmMultiple = false;
+  let seededFromPrefetch = false;
+  let lastPrefetchedReference = null;
+
+  $: if (prefetchedAgents !== lastPrefetchedReference) {
+    lastPrefetchedReference = prefetchedAgents;
+    if (Array.isArray(prefetchedAgents) && prefetchedAgents.length > 0) {
+      seedSuggestionsFrom(prefetchedAgents);
+      seededFromPrefetch = true;
+    } else if (seededFromPrefetch && !loading) {
+      agentSuggestions = [];
+      seededFromPrefetch = false;
+    }
+  }
+
+  $: if (!open) {
+    loading = false;
+    error = null;
+    usage = null;
+    confirmMultiple = false;
+  }
+
+  function seedSuggestionsFrom(agents) {
+    agentSuggestions = agents.map((agent) => ({
+      ...agent,
+      selected: true
+    }));
+    usage = null;
+    confirmMultiple = false;
+  }
+
+  function close() {
+    dispatch('close');
+  }
+
+  function buildPayload() {
+    const topic = (courseName || form.roleFocus || '').trim();
+    if (!topic) {
+      return { error: 'Provide a course name or role focus so AI can generate agents.' };
+    }
+
+    const contextParts = [];
+    if (form.roleFocus?.trim()) {
+      contextParts.push(`Role focus: ${form.roleFocus.trim()}`);
+    }
+    if (form.interactionStyle?.trim()) {
+      contextParts.push(`Interaction style: ${form.interactionStyle.trim()}`);
+    }
+    if (form.additionalNotes?.trim()) {
+      contextParts.push(form.additionalNotes.trim());
+    }
+
+    return {
+      payload: {
+        topic,
+        audience: '',
+        languageHint: languageHint?.trim() || '',
+        levelHint: levelHint?.trim() || '',
+        notes: contextParts.join('\n'),
+        agentContext: contextParts.join('\n'),
+        allowOpenAI
+      }
+    };
+  }
+
+  async function requestAgents() {
+    const { payload, error: payloadError } = buildPayload();
+    if (payloadError) {
+      error = payloadError;
+      return;
+    }
+
+    loading = true;
+    error = null;
+    confirmMultiple = false;
+
+    try {
+      const response = await fetch('/api/courses/ai-draft', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        const details = await safeParse(response);
+        throw new Error(
+          details?.message || details?.error || 'Failed to generate agent blueprints'
+        );
+      }
+
+      const data = await response.json();
+      const agents = Array.isArray(data.agents) ? data.agents : [];
+      if (agents.length === 0) {
+        error = 'The AI did not return any agent suggestions. Adjust the guidance and try again.';
+        agentSuggestions = [];
+        usage = data.usage || null;
+        dispatch('error', { message: error });
+        return;
+      }
+
+      agentSuggestions = agents.map((agent) => ({
+        ...agent,
+        selected: true
+      }));
+      usage = data.usage || null;
+      seededFromPrefetch = false;
+      dispatch('generated', { usage });
+    } catch (err) {
+      console.error('Agent blueprint generation failed', err);
+      error = err.message || 'Unable to generate agent blueprints. Please try again.';
+      dispatch('error', { message: error });
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function safeParse(response) {
+    try {
+      return await response.json();
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function toggleAgentSelection(index) {
+    agentSuggestions = agentSuggestions.map((entry, idx) =>
+      idx === index ? { ...entry, selected: !entry.selected } : entry
+    );
+    if (confirmMultiple) {
+      confirmMultiple = false;
+    }
+  }
+
+  function applyAgents() {
+    const selected = agentSuggestions
+      .filter((agent) => agent.selected)
+      .map((agent) => {
+        const rest = { ...agent };
+        delete rest.selected;
+        return rest;
+      });
+
+    if (selected.length === 0) {
+      error = 'Select at least one agent to continue.';
+      return;
+    }
+
+    if (selected.length > 1 && !confirmMultiple) {
+      confirmMultiple = true;
+      return;
+    }
+
+    confirmMultiple = false;
+    dispatch('apply', { agents: selected, usage });
+    close();
+  }
+</script>
+
+{#if open}
+  <div class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+    <div
+      class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto"
+    >
+      <div
+        class="flex items-center justify-between px-6 py-4 border-b border-stone-200 dark:border-gray-700"
+      >
+        <div class="flex items-center gap-3">
+          <div
+            class="p-2 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-200"
+          >
+            <Sparkles class="w-5 h-5" />
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold text-stone-900 dark:text-white">
+              AI Agent Blueprints
+            </h2>
+            <p class="text-sm text-stone-500 dark:text-gray-300">
+              Describe the agents you need and let AI propose ready-to-edit blueprints.
+            </p>
+          </div>
+        </div>
+        <Button variant="secondary" size="sm" on:click={close}>
+          <X class="w-4 h-4" />
+        </Button>
+      </div>
+
+      <div class="p-6 space-y-6">
+        <section class="space-y-4">
+          <h3 class="text-base font-semibold text-stone-900 dark:text-white">Guidance</h3>
+          <div class="space-y-4">
+            <div>
+              <label
+                for="agent-role-focus"
+                class="block text-sm font-medium text-stone-700 dark:text-gray-300 mb-2"
+              >
+                Agent role focus
+              </label>
+              <input
+                id="agent-role-focus"
+                type="text"
+                bind:value={form.roleFocus}
+                class="w-full rounded-lg border border-stone-300 px-4 py-2 text-stone-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder="e.g., Conversation coach for Spanish support calls"
+              />
+            </div>
+            <div>
+              <label
+                for="agent-interaction-style"
+                class="block text-sm font-medium text-stone-700 dark:text-gray-300 mb-2"
+              >
+                Preferred interaction style
+              </label>
+              <input
+                id="agent-interaction-style"
+                type="text"
+                bind:value={form.interactionStyle}
+                class="w-full rounded-lg border border-stone-300 px-4 py-2 text-stone-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder="e.g., Empathetic, structured feedback"
+              />
+            </div>
+            <div>
+              <label
+                for="agent-additional-notes"
+                class="block text-sm font-medium text-stone-700 dark:text-gray-300 mb-2"
+              >
+                Additional notes
+              </label>
+              <textarea
+                id="agent-additional-notes"
+                rows="3"
+                bind:value={form.additionalNotes}
+                class="w-full rounded-lg border border-stone-300 px-4 py-2 text-stone-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder="Mention data sources, tone guidelines, or sequencing preferences"
+              ></textarea>
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <div>
+              {#if error}
+                <p class="text-sm text-red-600 dark:text-red-300">{error}</p>
+              {:else if usage}
+                <p class="text-xs text-stone-500 dark:text-gray-400">
+                  Model: {usage.model} · Tokens: {usage.totalTokens}
+                </p>
+              {/if}
+            </div>
+            <div class="flex items-center gap-3">
+              {#if agentSuggestions.length > 0}
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  disabled={loading}
+                  on:click={requestAgents}
+                >
+                  <RefreshCw class="w-4 h-4 mr-2" />
+                  Regenerate
+                </Button>
+              {/if}
+              <Button type="button" size="sm" disabled={loading} on:click={requestAgents}>
+                {#if loading}
+                  Generating...
+                {:else}
+                  Generate agents
+                {/if}
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        {#if agentSuggestions.length > 0}
+          <section class="space-y-4">
+            <h3 class="text-base font-semibold text-stone-900 dark:text-white">Suggested agents</h3>
+            <div class="space-y-3">
+              {#each agentSuggestions as agent, index}
+                <div class="border border-stone-200 dark:border-gray-700 rounded-xl p-4">
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="flex-1 space-y-2">
+                      <div class="flex items-center gap-2">
+                        <Bot class="w-4 h-4 text-amber-600 dark:text-amber-300" />
+                        <h4 class="font-semibold text-stone-900 dark:text-white">{agent.name}</h4>
+                      </div>
+                      <p class="text-sm text-stone-600 dark:text-gray-300">{agent.description}</p>
+                      <p class="text-xs text-stone-500 dark:text-gray-400">
+                        <strong>Instructions:</strong>
+                        {agent.instructions}
+                      </p>
+                      <p class="text-xs text-stone-500 dark:text-gray-400">
+                        <strong>System prompt:</strong>
+                        {agent.systemPrompt}
+                      </p>
+                    </div>
+                    <label
+                      class="flex items-center gap-2 text-sm text-stone-700 dark:text-gray-200"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={agent.selected}
+                        on:change={() => toggleAgentSelection(index)}
+                      />
+                      Include
+                    </label>
+                  </div>
+                </div>
+              {/each}
+            </div>
+
+            {#if confirmMultiple}
+              <div
+                class="border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 rounded-lg p-4 flex items-start gap-3"
+              >
+                <AlertTriangle class="w-5 h-5 text-amber-600 dark:text-amber-300 mt-1" />
+                <div class="text-sm text-amber-800 dark:text-amber-100">
+                  <p class="font-semibold mb-1">Confirm multiple agents</p>
+                  <p>
+                    You are about to add {agentSuggestions.filter((agent) => agent.selected).length}
+                    agents. Confirm to apply them all.
+                  </p>
+                </div>
+              </div>
+            {/if}
+          </section>
+        {:else}
+          <div
+            class="border border-dashed border-stone-300 dark:border-gray-600 rounded-xl p-6 text-center text-sm text-stone-500 dark:text-gray-400"
+          >
+            Provide guidance and generate to see AI-suggested agents.
+          </div>
+        {/if}
+
+        <div class="flex justify-end gap-3 pt-4 border-t border-stone-200 dark:border-gray-700">
+          <Button type="button" variant="secondary" on:click={close}>Cancel</Button>
+          <Button
+            type="button"
+            on:click={applyAgents}
+            disabled={loading || agentSuggestions.length === 0}
+          >
+            Apply selected
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/modules/courses/components/CourseAIDraftPanel.svelte
+++ b/src/lib/modules/courses/components/CourseAIDraftPanel.svelte
@@ -1,0 +1,641 @@
+<script>
+  import { createEventDispatcher, onMount } from 'svelte';
+  import Button from '$shared/components/Button.svelte';
+  import { Sparkles, X, RefreshCw } from 'lucide-svelte';
+
+  export let courseName = '';
+  export let existingValues = {
+    language: '',
+    level: '',
+    description: '',
+    shortDescription: '',
+    skills: []
+  };
+  export let fieldDirty = {
+    language: false,
+    level: false,
+    description: false,
+    shortDescription: false,
+    skills: false
+  };
+  export let open = false;
+  export let allowOpenAI = true;
+
+  const dispatch = createEventDispatcher();
+
+  const DEFAULT_FORM = () => ({
+    topic: '',
+    audience: '',
+    languageHint: '',
+    levelHint: '',
+    notes: '',
+    agentContext: ''
+  });
+
+  let form = DEFAULT_FORM();
+  let loading = false;
+  let error = null;
+  let suggestions = null;
+  let usage = null;
+  let selectionsInitialised = false;
+  let selectedFields = {
+    language: false,
+    level: false,
+    description: false,
+    shortDescription: false
+  };
+  let skillSelections = [];
+  let agentSelections = [];
+
+  onMount(() => {
+    if (courseName && !form.topic) {
+      form.topic = courseName;
+    }
+    if (existingValues.language && !form.languageHint) {
+      form.languageHint = existingValues.language;
+    }
+    if (existingValues.level && !form.levelHint) {
+      form.levelHint = existingValues.level;
+    }
+  });
+
+  $: if (open) {
+    // Reset error state when opening
+    error = null;
+  }
+
+  $: if (!open) {
+    // Reset suggestions when modal is closed to allow a fresh start next time
+    suggestions = null;
+    usage = null;
+    selectionsInitialised = false;
+  }
+
+  $: if (suggestions && !selectionsInitialised) {
+    initialiseSelections();
+    selectionsInitialised = true;
+  }
+
+  $: if (!form.topic && courseName) {
+    form.topic = courseName;
+  }
+
+  $: if (!form.languageHint && existingValues.language) {
+    form.languageHint = existingValues.language;
+  }
+
+  $: if (!form.levelHint && existingValues.level) {
+    form.levelHint = existingValues.level;
+  }
+
+  function close() {
+    dispatch('close');
+  }
+
+  function initialiseSelections() {
+    selectedFields = {
+      language: shouldDefaultSelect(
+        existingValues.language,
+        fieldDirty.language,
+        suggestions.course.language
+      ),
+      level: shouldDefaultSelect(existingValues.level, fieldDirty.level, suggestions.course.level),
+      description: shouldDefaultSelect(
+        existingValues.description,
+        fieldDirty.description,
+        suggestions.course.description
+      ),
+      shortDescription: shouldDefaultSelect(
+        existingValues.shortDescription,
+        fieldDirty.shortDescription,
+        suggestions.course.shortDescription
+      )
+    };
+
+    const existingSkillSet = new Set(
+      (existingValues.skills || []).map((skill) => normaliseSkill(skill)).filter(Boolean)
+    );
+
+    skillSelections = (suggestions.course.skills || []).map((skill) => {
+      const normalised = normaliseSkill(skill);
+      return {
+        value: skill,
+        selected: !existingSkillSet.has(normalised) && !fieldDirty.skills
+      };
+    });
+
+    agentSelections = (suggestions.agents || []).map((agent) => ({
+      ...agent,
+      selected: true
+    }));
+  }
+
+  function shouldDefaultSelect(currentValue, dirty, suggestionValue) {
+    if (!suggestionValue) {
+      return false;
+    }
+    if (dirty) {
+      return false;
+    }
+    if (!currentValue) {
+      return true;
+    }
+    return currentValue.trim().length === 0;
+  }
+
+  function normaliseSkill(skill) {
+    return typeof skill === 'string' ? skill.trim().toLowerCase() : '';
+  }
+
+  function clampWords(text, limit) {
+    if (!text || typeof text !== 'string') {
+      return '';
+    }
+    const words = text.trim().split(/\s+/);
+    if (words.length <= limit) {
+      return words.join(' ');
+    }
+    return words.slice(0, limit).join(' ');
+  }
+
+  async function requestDraft(regenerate = false) {
+    if (!form.topic.trim()) {
+      error = 'Please provide a course topic before requesting AI assistance.';
+      return;
+    }
+
+    loading = true;
+    error = null;
+
+    try {
+      const response = await fetch('/api/courses/ai-draft', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          ...form,
+          allowOpenAI,
+          topic: form.topic.trim()
+        })
+      });
+
+      if (!response.ok) {
+        const payload = await safeParse(response);
+        throw new Error(payload?.message || payload?.error || 'Failed to generate AI draft');
+      }
+
+      const data = await response.json();
+      suggestions = {
+        course: {
+          language: data.course?.language?.trim() || '',
+          level: data.course?.level?.trim() || '',
+          description: clampWords(data.course?.description || '', 250),
+          shortDescription: clampWords(data.course?.shortDescription || '', 50),
+          skills: Array.isArray(data.course?.skills) ? data.course.skills.slice(0, 5) : []
+        },
+        agents: Array.isArray(data.agents) ? data.agents : []
+      };
+      usage = data.usage || null;
+      selectionsInitialised = false;
+      if (!regenerate) {
+        // Preserve prompt fields for potential regeneration
+        form.notes = data.lastNotes ?? form.notes;
+      }
+      dispatch('generated', { usage });
+    } catch (err) {
+      console.error('AI draft generation failed', err);
+      error = err.message || 'Unable to generate draft. Please try again.';
+      dispatch('error', { message: error });
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function safeParse(response) {
+    try {
+      return await response.json();
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function toggleSkillSelection(index) {
+    skillSelections = skillSelections.map((entry, idx) =>
+      idx === index ? { ...entry, selected: !entry.selected } : entry
+    );
+  }
+
+  function toggleAgentSelection(index) {
+    agentSelections = agentSelections.map((entry, idx) =>
+      idx === index ? { ...entry, selected: !entry.selected } : entry
+    );
+  }
+
+  function applySuggestions() {
+    if (!suggestions) {
+      return;
+    }
+
+    const coursePayload = {};
+
+    if (selectedFields.language && suggestions.course.language) {
+      coursePayload.language = suggestions.course.language;
+    }
+    if (selectedFields.level && suggestions.course.level) {
+      coursePayload.level = suggestions.course.level;
+    }
+    if (selectedFields.description && suggestions.course.description) {
+      coursePayload.description = clampWords(suggestions.course.description, 250);
+    }
+    if (selectedFields.shortDescription && suggestions.course.shortDescription) {
+      coursePayload.shortDescription = clampWords(suggestions.course.shortDescription, 50);
+    }
+
+    const selectedSkills = skillSelections
+      .filter((entry) => entry.selected && entry.value)
+      .map((entry) => entry.value);
+    if (selectedSkills.length > 0) {
+      coursePayload.skills = selectedSkills;
+    }
+
+    const selectedAgents = agentSelections
+      .filter((entry) => entry.selected)
+      .map((entry) => {
+        const agent = { ...entry };
+        delete agent.selected;
+        return agent;
+      });
+
+    dispatch('apply', {
+      course: coursePayload,
+      agents: selectedAgents,
+      usage
+    });
+    close();
+  }
+</script>
+
+{#if open}
+  <div class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+    <div
+      class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-3xl max-h-[90vh] overflow-y-auto"
+    >
+      <div
+        class="flex items-center justify-between px-6 py-4 border-b border-stone-200 dark:border-gray-700"
+      >
+        <div class="flex items-center gap-3">
+          <div
+            class="p-2 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-200"
+          >
+            <Sparkles class="w-5 h-5" />
+          </div>
+          <div>
+            <h2 class="text-lg font-semibold text-stone-900 dark:text-white">AI Course Draft</h2>
+            <p class="text-sm text-stone-500 dark:text-gray-300">
+              Provide a few hints and let AI propose course details and supporting agents.
+            </p>
+          </div>
+        </div>
+        <Button variant="secondary" size="sm" on:click={close}>
+          <X class="w-4 h-4" />
+        </Button>
+      </div>
+
+      <div class="p-6 space-y-6">
+        <section class="space-y-4">
+          <h3 class="text-base font-semibold text-stone-900 dark:text-white">Prompt</h3>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="md:col-span-2">
+              <label
+                for="course-topic"
+                class="block text-sm font-medium text-stone-700 dark:text-gray-300 mb-2"
+              >
+                Course topic *
+              </label>
+              <input
+                id="course-topic"
+                type="text"
+                bind:value={form.topic}
+                class="w-full rounded-lg border border-stone-300 px-4 py-2 text-stone-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder="e.g., Spanish for Remote Customer Support"
+              />
+            </div>
+            <div>
+              <label
+                for="course-audience"
+                class="block text-sm font-medium text-stone-700 dark:text-gray-300 mb-2"
+              >
+                Target audience
+              </label>
+              <input
+                id="course-audience"
+                type="text"
+                bind:value={form.audience}
+                class="w-full rounded-lg border border-stone-300 px-4 py-2 text-stone-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder="e.g., English-speaking support agents"
+              />
+            </div>
+            <div>
+              <label
+                for="course-language-hint"
+                class="block text-sm font-medium text-stone-700 dark:text-gray-300 mb-2"
+              >
+                Preferred language
+              </label>
+              <input
+                id="course-language-hint"
+                type="text"
+                bind:value={form.languageHint}
+                class="w-full rounded-lg border border-stone-300 px-4 py-2 text-stone-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder="e.g., Spanish"
+              />
+            </div>
+            <div>
+              <label
+                for="course-level-hint"
+                class="block text-sm font-medium text-stone-700 dark:text-gray-300 mb-2"
+              >
+                Level guidance
+              </label>
+              <input
+                id="course-level-hint"
+                type="text"
+                bind:value={form.levelHint}
+                class="w-full rounded-lg border border-stone-300 px-4 py-2 text-stone-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder="e.g., B2"
+              />
+            </div>
+            <div class="md:col-span-2">
+              <label
+                for="course-notes"
+                class="block text-sm font-medium text-stone-700 dark:text-gray-300 mb-2"
+              >
+                Additional notes
+              </label>
+              <textarea
+                id="course-notes"
+                rows="2"
+                bind:value={form.notes}
+                class="w-full rounded-lg border border-stone-300 px-4 py-2 text-stone-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder="Highlight tone, focus areas, or special requirements"
+              ></textarea>
+            </div>
+            <div class="md:col-span-2">
+              <label
+                for="course-agent-context"
+                class="block text-sm font-medium text-stone-700 dark:text-gray-300 mb-2"
+              >
+                Agent assistance context
+              </label>
+              <textarea
+                id="course-agent-context"
+                rows="2"
+                bind:value={form.agentContext}
+                class="w-full rounded-lg border border-stone-300 px-4 py-2 text-stone-900 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                placeholder="Describe the types of agents or scenarios you'd like support for"
+              ></textarea>
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <div>
+              {#if error}
+                <p class="text-sm text-red-600 dark:text-red-300">{error}</p>
+              {:else if usage}
+                <p class="text-xs text-stone-500 dark:text-gray-400">
+                  Model: {usage.model} · Tokens: {usage.totalTokens}
+                </p>
+              {/if}
+            </div>
+            <div class="flex items-center gap-3">
+              {#if suggestions}
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  disabled={loading}
+                  on:click={() => requestDraft(true)}
+                >
+                  <RefreshCw class="w-4 h-4 mr-2" />
+                  Regenerate
+                </Button>
+              {/if}
+              <Button
+                type="button"
+                size="sm"
+                disabled={loading}
+                on:click={() => requestDraft(false)}
+              >
+                {#if loading}
+                  Generating...
+                {:else}
+                  Generate draft
+                {/if}
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        {#if suggestions}
+          <section class="space-y-4">
+            <h3 class="text-base font-semibold text-stone-900 dark:text-white">
+              Review suggestions
+            </h3>
+            <div class="space-y-4">
+              <div class="border border-stone-200 dark:border-gray-700 rounded-xl p-4">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1 space-y-2">
+                    <h4 class="font-semibold text-stone-900 dark:text-white">Language</h4>
+                    <p class="text-sm text-stone-500 dark:text-gray-400">
+                      Current: {existingValues.language || '—'}
+                    </p>
+                    <p class="text-sm text-stone-700 dark:text-gray-200">
+                      Suggestion: {suggestions.course.language || '—'}
+                    </p>
+                  </div>
+                  <div class="flex items-center gap-2 text-sm text-stone-700 dark:text-gray-200">
+                    <input
+                      id="course-language-apply"
+                      type="checkbox"
+                      bind:checked={selectedFields.language}
+                    />
+                    <label for="course-language-apply" class="cursor-pointer">Apply</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="border border-stone-200 dark:border-gray-700 rounded-xl p-4">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1 space-y-2">
+                    <h4 class="font-semibold text-stone-900 dark:text-white">Level</h4>
+                    <p class="text-sm text-stone-500 dark:text-gray-400">
+                      Current: {existingValues.level || '—'}
+                    </p>
+                    <p class="text-sm text-stone-700 dark:text-gray-200">
+                      Suggestion: {suggestions.course.level || '—'}
+                    </p>
+                  </div>
+                  <div class="flex items-center gap-2 text-sm text-stone-700 dark:text-gray-200">
+                    <input
+                      id="course-level-apply"
+                      type="checkbox"
+                      bind:checked={selectedFields.level}
+                    />
+                    <label for="course-level-apply" class="cursor-pointer">Apply</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="border border-stone-200 dark:border-gray-700 rounded-xl p-4">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1 space-y-2">
+                    <h4 class="font-semibold text-stone-900 dark:text-white">
+                      Description (≤250 words)
+                    </h4>
+                    <p class="text-sm text-stone-500 dark:text-gray-400 whitespace-pre-line">
+                      Current: {existingValues.description || '—'}
+                    </p>
+                    <p class="text-sm text-stone-700 dark:text-gray-200 whitespace-pre-line">
+                      Suggestion: {suggestions.course.description || '—'}
+                    </p>
+                  </div>
+                  <div class="flex items-center gap-2 text-sm text-stone-700 dark:text-gray-200">
+                    <input
+                      id="course-description-apply"
+                      type="checkbox"
+                      bind:checked={selectedFields.description}
+                    />
+                    <label for="course-description-apply" class="cursor-pointer">Apply</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="border border-stone-200 dark:border-gray-700 rounded-xl p-4">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1 space-y-2">
+                    <h4 class="font-semibold text-stone-900 dark:text-white">
+                      Short description (≤50 words)
+                    </h4>
+                    <p class="text-sm text-stone-500 dark:text-gray-400 whitespace-pre-line">
+                      Current: {existingValues.shortDescription || '—'}
+                    </p>
+                    <p class="text-sm text-stone-700 dark:text-gray-200 whitespace-pre-line">
+                      Suggestion: {suggestions.course.shortDescription || '—'}
+                    </p>
+                  </div>
+                  <div class="flex items-center gap-2 text-sm text-stone-700 dark:text-gray-200">
+                    <input
+                      id="course-short-description-apply"
+                      type="checkbox"
+                      bind:checked={selectedFields.shortDescription}
+                    />
+                    <label for="course-short-description-apply" class="cursor-pointer">Apply</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="border border-stone-200 dark:border-gray-700 rounded-xl p-4 space-y-3">
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1">
+                    <h4 class="font-semibold text-stone-900 dark:text-white">Skills (max 5)</h4>
+                    <p class="text-sm text-stone-500 dark:text-gray-400">
+                      Current: {(existingValues.skills || []).length > 0
+                        ? existingValues.skills.join(', ')
+                        : '—'}
+                    </p>
+                  </div>
+                </div>
+                {#if skillSelections.length > 0}
+                  <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+                    {#each skillSelections as skill, index}
+                      <label
+                        class="flex items-center gap-2 text-sm text-stone-700 dark:text-gray-200 border border-stone-200 dark:border-gray-700 rounded-lg px-3 py-2"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={skill.selected}
+                          on:change={() => toggleSkillSelection(index)}
+                        />
+                        {skill.value}
+                      </label>
+                    {/each}
+                  </div>
+                {:else}
+                  <p class="text-sm text-stone-500 dark:text-gray-400">
+                    No skill suggestions returned.
+                  </p>
+                {/if}
+              </div>
+
+              {#if agentSelections.length > 0}
+                <div
+                  class="border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/10 rounded-xl p-4 space-y-3"
+                >
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="flex-1">
+                      <h4 class="font-semibold text-amber-900 dark:text-amber-200">
+                        Suggested agents ({agentSelections.length})
+                      </h4>
+                      <p class="text-sm text-amber-800 dark:text-amber-100">
+                        Select agents to pass into the agent manager for review.
+                      </p>
+                    </div>
+                  </div>
+                  <div class="space-y-3">
+                    {#each agentSelections as agent, index}
+                      <div class="border border-amber-200 dark:border-amber-700 rounded-lg p-3">
+                        <div class="flex items-start justify-between gap-3">
+                          <div class="flex-1">
+                            <h5 class="font-semibold text-amber-900 dark:text-amber-100">
+                              {agent.name}
+                            </h5>
+                            <p class="text-sm text-amber-800 dark:text-amber-100 mb-2">
+                              {agent.description}
+                            </p>
+                            <p class="text-xs text-amber-700 dark:text-amber-200 mb-1">
+                              <strong>Instructions:</strong>
+                              {agent.instructions}
+                            </p>
+                            <p class="text-xs text-amber-700 dark:text-amber-200">
+                              <strong>System prompt:</strong>
+                              {agent.systemPrompt}
+                            </p>
+                          </div>
+                          <label
+                            class="flex items-center gap-2 text-sm text-amber-900 dark:text-amber-200"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={agent.selected}
+                              on:change={() => toggleAgentSelection(index)}
+                            />
+                            Include
+                          </label>
+                        </div>
+                      </div>
+                    {/each}
+                  </div>
+                </div>
+              {/if}
+            </div>
+          </section>
+
+          <div class="flex justify-end gap-3 pt-4 border-t border-stone-200 dark:border-gray-700">
+            <Button type="button" variant="secondary" on:click={close}>Cancel</Button>
+            <Button type="button" on:click={applySuggestions} disabled={loading || !suggestions}>
+              Apply selected
+            </Button>
+          </div>
+        {/if}
+
+        {#if !suggestions}
+          <div
+            class="border border-dashed border-stone-300 dark:border-gray-600 rounded-xl p-6 text-center text-sm text-stone-500 dark:text-gray-400"
+          >
+            Provide a topic and optional guidance, then generate a draft to review AI suggestions.
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/routes/api/courses/ai-draft/+server.js
+++ b/src/routes/api/courses/ai-draft/+server.js
@@ -1,0 +1,224 @@
+import { json } from '@sveltejs/kit';
+import { OPENAI_CONFIG } from '$lib/config/api';
+
+const DESCRIPTION_WORD_LIMIT = 250;
+const SHORT_DESCRIPTION_WORD_LIMIT = 50;
+const SKILL_LIMIT = 5;
+const AGENT_LIMIT = 3;
+
+function clampWords(text, limit) {
+  if (!text || typeof text !== 'string') {
+    return '';
+  }
+  const words = text.trim().split(/\s+/);
+  if (words.length <= limit) {
+    return words.join(' ');
+  }
+  return words.slice(0, limit).join(' ');
+}
+
+function sanitizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function sanitizeSkills(skills) {
+  if (!Array.isArray(skills)) {
+    return [];
+  }
+  const seen = new Set();
+  const cleaned = [];
+  for (const skill of skills) {
+    const text = sanitizeString(skill);
+    if (!text) continue;
+    const key = text.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    cleaned.push(text);
+    if (cleaned.length >= SKILL_LIMIT) {
+      break;
+    }
+  }
+  return cleaned;
+}
+
+function sanitizeAgent(agent) {
+  if (!agent || typeof agent !== 'object') {
+    return null;
+  }
+  return {
+    name: sanitizeString(agent.name),
+    description: sanitizeString(agent.description),
+    instructions: sanitizeString(agent.instructions),
+    systemPrompt: sanitizeString(agent.systemPrompt)
+  };
+}
+
+async function callOpenAI(messages) {
+  const payload = {
+    model: OPENAI_CONFIG.MODEL,
+    temperature: OPENAI_CONFIG.TEMPERATURE,
+    max_tokens: Math.min(OPENAI_CONFIG.MAX_TOKENS || 800, 1500),
+    response_format: { type: 'json_object' },
+    messages
+  };
+
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${OPENAI_CONFIG.API_KEY}`
+  };
+
+  const maxRetries = OPENAI_CONFIG.RETRY?.MAX_RETRIES ?? 2;
+  const retryDelay = OPENAI_CONFIG.RETRY?.RETRY_DELAY ?? 1000;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), OPENAI_CONFIG.TIMEOUT || 30000);
+
+    try {
+      const response = await fetch(OPENAI_CONFIG.API_URL, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        const errorPayload = await safeParseJSON(response);
+        const message =
+          errorPayload?.error?.message || errorPayload?.message || response.statusText;
+        throw new Error(message);
+      }
+
+      const data = await response.json();
+      const choice = data.choices?.[0]?.message?.content;
+      if (!choice) {
+        throw new Error('OpenAI response missing content');
+      }
+
+      let parsed;
+      try {
+        parsed = JSON.parse(choice);
+      } catch (err) {
+        throw new Error('OpenAI response was not valid JSON');
+      }
+
+      return {
+        data: parsed,
+        usage: data.usage
+          ? { totalTokens: data.usage.total_tokens, model: data.model || OPENAI_CONFIG.MODEL }
+          : null
+      };
+    } catch (error) {
+      if (attempt === maxRetries) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, retryDelay * (attempt + 1)));
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw new Error('Failed to contact OpenAI');
+}
+
+async function safeParseJSON(response) {
+  try {
+    return await response.json();
+  } catch (err) {
+    return null;
+  }
+}
+
+export async function POST({ request, locals }) {
+  if (!locals.user) {
+    return json({ message: 'Authentication required' }, { status: 401 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch (err) {
+    return json({ message: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const {
+    topic,
+    audience = '',
+    languageHint = '',
+    levelHint = '',
+    notes = '',
+    agentContext = '',
+    allowOpenAI = true
+  } = body || {};
+
+  if (!allowOpenAI) {
+    return json({ message: 'OpenAI drafting is disabled for this course.' }, { status: 403 });
+  }
+
+  if (!topic || typeof topic !== 'string' || !topic.trim()) {
+    return json({ message: 'Course topic is required.' }, { status: 400 });
+  }
+
+  const systemPrompt =
+    `You are an expert instructional designer and AI systems architect. ` +
+    `Return a strict JSON object matching this schema: ` +
+    `{"course": {"language": string, "level": string, "description": string, "shortDescription": string, "skills": string[]}, ` +
+    `"agents": [{"name": string, "description": string, "instructions": string, "systemPrompt": string}]}. ` +
+    `Descriptions must respect word limits (course.description ≤ ${DESCRIPTION_WORD_LIMIT} words, course.shortDescription ≤ ${SHORT_DESCRIPTION_WORD_LIMIT} words). ` +
+    `Include up to ${SKILL_LIMIT} concise skills (single phrases). ` +
+    `Agents array can contain zero to ${AGENT_LIMIT} entries. Use adult learner appropriate tone.`;
+
+  const userPromptLines = [`Course topic: ${topic.trim()}`];
+
+  if (audience) {
+    userPromptLines.push(`Target audience: ${audience}`);
+  }
+  if (languageHint) {
+    userPromptLines.push(`Preferred language: ${languageHint}`);
+  }
+  if (levelHint) {
+    userPromptLines.push(`Proficiency level guidance: ${levelHint}`);
+  }
+  if (notes) {
+    userPromptLines.push(`Additional notes: ${notes}`);
+  }
+  if (agentContext) {
+    userPromptLines.push(`Agent requirements: ${agentContext}`);
+  }
+
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userPromptLines.join('\n') }
+  ];
+
+  try {
+    const { data, usage } = await callOpenAI(messages);
+
+    const course = {
+      language: sanitizeString(data.course?.language),
+      level: sanitizeString(data.course?.level),
+      description: clampWords(data.course?.description, DESCRIPTION_WORD_LIMIT),
+      shortDescription: clampWords(data.course?.shortDescription, SHORT_DESCRIPTION_WORD_LIMIT),
+      skills: sanitizeSkills(data.course?.skills)
+    };
+
+    const agents = Array.isArray(data.agents)
+      ? data.agents
+          .slice(0, AGENT_LIMIT)
+          .map(sanitizeAgent)
+          .filter((agent) => agent && agent.name && agent.description && agent.systemPrompt)
+      : [];
+
+    return json({ course, agents, usage });
+  } catch (error) {
+    console.error('AI draft generation failed', {
+      message: error.message,
+      userId: locals.user?.id,
+      topicLength: topic?.length || 0
+    });
+    return json(
+      { message: 'Failed to generate AI draft. Please try again later.' },
+      { status: 500 }
+    );
+  }
+}

--- a/tests/unit/courses/aiDraft.server.test.js
+++ b/tests/unit/courses/aiDraft.server.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST } from '../../../src/routes/api/courses/ai-draft/+server.js';
+
+function buildRequest(body) {
+  return new Request('http://localhost/api/courses/ai-draft', {
+    method: 'POST',
+    body: JSON.stringify(body)
+  });
+}
+
+describe('POST /api/courses/ai-draft', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+  });
+
+  it('requires authentication', async () => {
+    const response = await POST({
+      request: buildRequest({ topic: 'Test Course' }),
+      locals: { user: null }
+    });
+
+    expect(response.status).toBe(401);
+    const payload = await response.json();
+    expect(payload.message).toMatch(/authentication/i);
+  });
+
+  it('validates topic field', async () => {
+    const response = await POST({
+      request: buildRequest({ topic: '  ', allowOpenAI: true }),
+      locals: { user: { id: 'user-1' } }
+    });
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.message).toMatch(/topic/i);
+  });
+
+  it('rejects when OpenAI usage is disabled', async () => {
+    const response = await POST({
+      request: buildRequest({ topic: 'Course', allowOpenAI: false }),
+      locals: { user: { id: 'user-1' } }
+    });
+
+    expect(response.status).toBe(403);
+    const payload = await response.json();
+    expect(payload.message).toMatch(/disabled/i);
+  });
+
+  it('returns sanitised course and agent suggestions', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                course: {
+                  language: ' Spanish ',
+                  level: ' B2 ',
+                  description: 'word '.repeat(260),
+                  shortDescription: 'short '.repeat(80),
+                  skills: [
+                    'Skill A',
+                    'Skill B',
+                    'Skill C',
+                    'Skill A',
+                    'Skill D',
+                    'Skill E',
+                    'Skill F'
+                  ]
+                },
+                agents: [
+                  {
+                    name: 'Coach',
+                    description: 'Helps learners',
+                    instructions: 'Guide conversation',
+                    systemPrompt: 'You are a coach'
+                  },
+                  {
+                    name: 'Extra',
+                    description: 'Should be trimmed',
+                    instructions: 'Do more',
+                    systemPrompt: 'Extra agent'
+                  },
+                  {
+                    name: 'Third',
+                    description: 'Third agent',
+                    instructions: 'Assist',
+                    systemPrompt: 'Third agent'
+                  },
+                  {
+                    name: 'Overflow',
+                    description: 'Should not appear',
+                    instructions: 'Ignore',
+                    systemPrompt: 'Ignore'
+                  }
+                ]
+              })
+            }
+          }
+        ],
+        usage: { total_tokens: 512 },
+        model: 'gpt-test'
+      })
+    };
+
+    fetch.mockResolvedValue(mockResponse);
+
+    const response = await POST({
+      request: buildRequest({ topic: 'Spanish course', allowOpenAI: true }),
+      locals: { user: { id: 'user-1' } }
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload.course.language).toBe('Spanish');
+    expect(payload.course.level).toBe('B2');
+    const descriptionWordCount = payload.course.description.split(/\s+/).length;
+    expect(descriptionWordCount).toBeLessThanOrEqual(250);
+    const shortDescriptionWordCount = payload.course.shortDescription.split(/\s+/).length;
+    expect(shortDescriptionWordCount).toBeLessThanOrEqual(50);
+    expect(payload.course.skills).toHaveLength(5);
+    expect(new Set(payload.course.skills).size).toBe(payload.course.skills.length);
+
+    expect(payload.agents).toHaveLength(3);
+    expect(payload.agents[0].name).toBe('Coach');
+    expect(payload.agents[0].description).toBe('Helps learners');
+    expect(payload.usage.totalTokens).toBe(512);
+    expect(payload.usage.model).toBe('gpt-test');
+  });
+
+  it('returns 500 when OpenAI call fails', async () => {
+    fetch.mockRejectedValue(new Error('network error'));
+
+    const response = await POST({
+      request: buildRequest({ topic: 'Course', allowOpenAI: true }),
+      locals: { user: { id: 'user-1' } }
+    });
+
+    expect(response.status).toBe(500);
+    const payload = await response.json();
+    expect(payload.message).toMatch(/failed/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add an AI course drafting panel with field-level selection, dirty tracking, and usage reporting
- integrate AI-generated agent blueprints into the agent manager with suggestion review and multi-agent confirmation
- provide an authenticated /api/courses/ai-draft endpoint that calls OpenAI, sanitises responses, and is covered by unit tests

## Testing
- npm run lint
- CI=1 npx vitest run tests/unit/courses/aiDraft.server.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df06e5d1b0832489486becd684fea7