### PR TITLE
fix: normalize mock auth user ids

### DIFF
--- a/src/lib/modules/auth/services/LocalAuthService.js
+++ b/src/lib/modules/auth/services/LocalAuthService.js
@@ -47,7 +47,7 @@ export class LocalAuthService extends IAuthService {
       // Simulate login for demo users
       if (email === 'admin@example.com' && password === 'password') {
         const userData = {
-          id: 1,
+          id: '1',
           name: 'Admin User',
           email: 'admin@example.com',
           role: 'admin'
@@ -69,7 +69,7 @@ export class LocalAuthService extends IAuthService {
         return userData;
       } else if (email === 'student@example.com' && password === 'password') {
         const userData = {
-          id: 2,
+          id: '2',
           name: 'Student User',
           email: 'student@example.com',
           role: 'student'
@@ -91,7 +91,7 @@ export class LocalAuthService extends IAuthService {
         return userData;
       } else if (email === 'student1@example.com' && password === 'Demo123') {
         const userData = {
-          id: 3,
+          id: '3',
           name: 'Student One',
           email: 'student1@example.com',
           role: 'student'
@@ -113,7 +113,7 @@ export class LocalAuthService extends IAuthService {
         return userData;
       } else if (email === 'student2@example.com' && password === 'Demo321') {
         const userData = {
-          id: 4,
+          id: '4',
           name: 'Student Two',
           email: 'student2@example.com',
           role: 'student'
@@ -177,7 +177,7 @@ export class LocalAuthService extends IAuthService {
       // Simulate successful registration
       setNotification('Registration successful. Please log in.', 'success');
       return {
-        id: 3,
+        id: '3',
         name: userData.name,
         email: userData.email,
         role: 'student'

--- a/tests/auth/stores.test.js
+++ b/tests/auth/stores.test.js
@@ -11,7 +11,7 @@ describe('auth stores', () => {
     await login('Admin', 'Demo543');
     expect(get(isAuthenticated)).toBe(true);
     expect(get(user)).toEqual({
-      id: 0,
+      id: '0',
       name: 'Admin',
       email: 'admin@example.com',
       role: 'admin'


### PR DESCRIPTION
## Summary
- normalize mock auth user data so persisted IDs are always strings
- update local auth service fixtures to match the string ID expectation
- adjust the auth store unit test to assert the new ID shape

## Testing
- npm run lint
- npm run test:run -- --reporter=basic --silent *(fails: VoiceUXMetricsTracker task/error tracking expectation)*
- npm run test:integration -- --reporter=basic --silent *(fails: multilingualIntegration suite requires detectUserLanguage)*
- npm run test:e2e -- --reporter=basic --silent *(fails: waiting phrase service and Playwright dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68df19fa26cc83248d8421ee81a883b5