### PR TITLE
Add shareable URLs for course actions

### DIFF
--- a/src/lib/utils/slugify.js
+++ b/src/lib/utils/slugify.js
@@ -1,0 +1,22 @@
+export const slugify = (value, fallback = '') => {
+  if (!value && !fallback) {
+    return '';
+  }
+
+  const base = value ?? fallback;
+
+  const slug = base
+    .toString()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (slug) {
+    return slug;
+  }
+
+  return fallback ? slugify(fallback) : '';
+};


### PR DESCRIPTION
## Summary
- add a reusable slugify helper for generating stable course slugs
- update My Courses actions to navigate with course-specific URLs for each option
- sync the catalogue page with URL query parameters to trigger the requested course actions

## Testing
- npm run check *(fails: tsconfig missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68df2438d174832482feebaa97b1bf13