### PR TITLE
Handle database readiness errors for session APIs

### DIFF
--- a/src/lib/modules/session/components/SessionsList.svelte
+++ b/src/lib/modules/session/components/SessionsList.svelte
@@ -27,6 +27,8 @@
   let filterDateFrom = '';
   let filterDateTo = '';
 
+  const DATABASE_NOT_READY_MESSAGE = 'Session persistence is unavailable. Run "prisma generate" and ensure the Postgres instance is running.';
+
   // Reactive statements
   $: sessions = $sessionStore?.sessions || [];
   $: loading = $isSessionLoading || $sessionStore?.loading || false;
@@ -38,6 +40,9 @@
   $: filtersActive = $hasActiveFilters;
   $: filtersCount = $activeFiltersCount;
   $: currentFilters = $sessionStore.filters;
+  $: persistence = $sessionStore.persistence;
+  $: persistenceUnavailable = persistence?.available === false;
+  $: persistenceMessage = persistence?.message || DATABASE_NOT_READY_MESSAGE;
 
   // Language options
   const languageOptions = [
@@ -387,6 +392,15 @@
       </div>
     {/if}
   </div>
+
+  {#if persistenceUnavailable}
+    <div class="px-4">
+      <div class="mb-4 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 shadow-sm dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-200" role="alert">
+        <p class="font-semibold">Session persistence unavailable</p>
+        <p class="mt-1 leading-snug">{persistenceMessage}</p>
+      </div>
+    </div>
+  {/if}
 
   <!-- Sessions list -->
   <div class="flex-1 overflow-y-auto">

--- a/src/routes/api/sessions/+server.js
+++ b/src/routes/api/sessions/+server.js
@@ -83,6 +83,11 @@ export async function GET({ url, locals }) {
   } catch (error) {
     console.error('Error in GET /api/sessions:', error);
 
+    if (error instanceof SessionError && error.code === 'DATABASE_NOT_READY') {
+      const message = 'Session persistence is unavailable. Run "prisma generate" and ensure the Postgres instance is running.';
+      return json({ error: message, message, code: error.code }, { status: 503 });
+    }
+
     if (error instanceof SessionValidationError) {
       return json({ error: error.message }, { status: 400 });
     }
@@ -143,6 +148,11 @@ export async function POST({ request, locals }) {
     return json(session, { status: 201 });
   } catch (error) {
     console.error('Error in POST /api/sessions:', error);
+
+    if (error instanceof SessionError && error.code === 'DATABASE_NOT_READY') {
+      const message = 'Session persistence is unavailable. Run "prisma generate" and ensure the Postgres instance is running.';
+      return json({ error: message, message, code: error.code }, { status: 503 });
+    }
 
     if (error instanceof SessionValidationError) {
       return json({ error: error.message }, { status: 400 });

--- a/src/routes/api/sessions/[id]/+server.js
+++ b/src/routes/api/sessions/[id]/+server.js
@@ -27,6 +27,11 @@ export async function GET({ params, url, locals }) {
   } catch (error) {
     console.error(`Error in GET /api/sessions/${params.id}:`, error);
 
+    if (error instanceof SessionError && error.code === 'DATABASE_NOT_READY') {
+      const message = 'Session persistence is unavailable. Run "prisma generate" and ensure the Postgres instance is running.';
+      return json({ error: message, message, code: error.code }, { status: 503 });
+    }
+
     if (error instanceof SessionNotFoundError) {
       return json({ error: 'Session not found' }, { status: 404 });
     }
@@ -111,6 +116,11 @@ export async function PUT({ params, request, locals }) {
   } catch (error) {
     console.error(`Error in PUT /api/sessions/${params.id}:`, error);
 
+    if (error instanceof SessionError && error.code === 'DATABASE_NOT_READY') {
+      const message = 'Session persistence is unavailable. Run "prisma generate" and ensure the Postgres instance is running.';
+      return json({ error: message, message, code: error.code }, { status: 503 });
+    }
+
     if (error instanceof SessionNotFoundError) {
       return json({ error: 'Session not found' }, { status: 404 });
     }
@@ -149,6 +159,11 @@ export async function DELETE({ params, locals }) {
     return json({ success: true, message: 'Session deleted successfully' });
   } catch (error) {
     console.error(`Error in DELETE /api/sessions/${params.id}:`, error);
+
+    if (error instanceof SessionError && error.code === 'DATABASE_NOT_READY') {
+      const message = 'Session persistence is unavailable. Run "prisma generate" and ensure the Postgres instance is running.';
+      return json({ error: message, message, code: error.code }, { status: 503 });
+    }
 
     if (error instanceof SessionNotFoundError) {
       return json({ error: 'Session not found' }, { status: 404 });

--- a/src/routes/api/sessions/search/+server.js
+++ b/src/routes/api/sessions/search/+server.js
@@ -62,6 +62,11 @@ export async function GET({ url, locals }) {
   } catch (error) {
     console.error('Error in GET /api/sessions/search:', error);
 
+    if (error instanceof SessionError && error.code === 'DATABASE_NOT_READY') {
+      const message = 'Session persistence is unavailable. Run "prisma generate" and ensure the Postgres instance is running.';
+      return json({ error: message, message, code: error.code }, { status: 503 });
+    }
+
     if (error instanceof SessionValidationError) {
       return json({ error: error.message }, { status: 400 });
     }

--- a/src/routes/api/sessions/stats/+server.js
+++ b/src/routes/api/sessions/stats/+server.js
@@ -47,6 +47,11 @@ export async function GET({ locals }) {
   } catch (error) {
     console.error('Error in GET /api/sessions/stats:', error);
 
+    if ((error instanceof SessionError || error instanceof MessageError) && error.code === 'DATABASE_NOT_READY') {
+      const message = 'Session persistence is unavailable. Run "prisma generate" and ensure the Postgres instance is running.';
+      return json({ error: message, message, code: error.code }, { status: 503 });
+    }
+
     if (error instanceof SessionError || error instanceof MessageError) {
       return json({ error: 'Failed to retrieve statistics' }, { status: 500 });
     }


### PR DESCRIPTION
## Summary
- wrap Prisma client loading in a DatabaseNotReadyError to surface missing `prisma generate` or database issues early
- propagate database readiness failures through the session service and session API endpoints to return a 503 with remediation guidance
- update the session store and UI to show a persistence warning banner when the backend signals the database is not ready

## Testing
- `npm run check` *(fails: Could not find tsconfig/jsconfig file at ./tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e44cd74d508324811bd77fe02e2688