### PR TITLE
Normalize unicode integrals in math messages

### DIFF
--- a/tests/unit/chat/MathMessage.test.js
+++ b/tests/unit/chat/MathMessage.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import MathMessage from '../../../src/lib/modules/chat/components/MathMessage.svelte';
+
+describe('MathMessage', () => {
+  it('normalizes unicode integrals into KaTeX-renderable math', () => {
+    const { container } = render(MathMessage, {
+      props: {
+        content: '∫ 2x dz = x^(2) + C'
+      }
+    });
+
+    expect(container.querySelector('.katex')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- normalize Unicode integral lines by mapping symbols to LaTeX, spacing differentials, and wrapping with math delimiters
- add handling for exponent patterns like x^(2) when processing integral expressions
- add a MathMessage unit test covering Unicode integral normalization

## Testing
- npm run test:run -- tests/unit/chat/MathMessage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e59c2264d48324816258962afcdea1