### PR TITLE
Fix MathMessage unicode integral parsing

### DIFF
--- a/src/lib/modules/chat/components/MathMessage.svelte
+++ b/src/lib/modules/chat/components/MathMessage.svelte
@@ -17,7 +17,67 @@
       return [{ type: 'text', content: text }];
     }
 
-    let processedText = text;
+    const integralSymbolMap = {
+      '∫': '\\int',
+      '∬': '\\iint',
+      '∭': '\\iiint',
+      '⨌': '\\iiiint',
+      '∮': '\\oint',
+      '∯': '\\oiint',
+      '∰': '\\oiiint',
+      '∱': '\\int',
+      '∲': '\\int',
+      '∳': '\\int'
+    };
+
+    const integralPlaceholders = new Map();
+
+    const linesWithoutIntegrals = text.split('\n').map((line, index) => {
+      const leadingWhitespaceMatch = line.match(/^\s*/);
+      const leadingWhitespace = leadingWhitespaceMatch ? leadingWhitespaceMatch[0] : '';
+      const lineWithoutIndent = line.slice(leadingWhitespace.length);
+
+      if (lineWithoutIndent.startsWith('$$')) {
+        return line;
+      }
+
+      const integralMatch = lineWithoutIndent.match(/^([∫∬∭⨌∮∯∰∱∲∳])\s*(.*)$/);
+
+      if (!integralMatch) {
+        return line;
+      }
+
+      const [, integralSymbol, restOfLine] = integralMatch;
+      const latexIntegral = integralSymbolMap[integralSymbol] || '\\int';
+
+      let normalizedRest = restOfLine.trim();
+
+      normalizedRest = normalizedRest.replace(
+        /([a-zA-Z0-9\\}\]])\^\(([^)]+)\)/g,
+        (_, base, exponent) => `${base}^{${exponent}}`
+      );
+
+      normalizedRest = normalizedRest.replace(
+        /(?<!\\,)d([a-zA-Z])\b/g,
+        (_, variable) => String.raw`\, d${variable}`
+      );
+
+      const integralExpression = `${latexIntegral} ${normalizedRest}`.trim();
+      const latexLine = `${leadingWhitespace}$$${integralExpression}$$`;
+
+      const placeholder = `__INTEGRAL_PLACEHOLDER_${index}__`;
+      integralPlaceholders.set(placeholder, latexLine);
+
+      return placeholder;
+    });
+
+    let processedText = linesWithoutIntegrals.join('\n');
+
+    // Normalize exponent notation like x^(2) -> x^{2} globally (outside integral placeholders)
+    processedText = processedText.replace(
+      /([a-zA-Z0-9\\}\]])\^\(([^)]+)\)/g,
+      (_, base, exponent) => `${base}^{${exponent}}`
+    );
 
     // Convert LaTeX-like expressions to proper LaTeX
     // Handle complete integral equations: \int x^2 dx = \frac{x^3}{3} + C
@@ -33,19 +93,31 @@
     );
 
     // Handle simple integrals: \int x^2 dx
-    processedText = processedText.replace(/\\int\s+([^d=]+)\s*d([a-zA-Z])/g, '$\\int $1 \\, d$2$');
+    processedText = processedText.replace(
+      /\\int\s+([^d=]+)\s*d([a-zA-Z])/g,
+      (_, integrand, variable) => String.raw`$\int ${integrand} \, d${variable}$`
+    );
 
     // Handle fractions: \frac{x^3}{3}
-    processedText = processedText.replace(/\\frac\{([^}]+)\}\{([^}]+)\}/g, '$\\frac{$1}{$2}$');
+    processedText = processedText.replace(
+      /\\frac\{([^}]+)\}\{([^}]+)\}/g,
+      (_, numerator, denominator) => String.raw`$\frac{${numerator}}{${denominator}}$`
+    );
 
     // Handle simple fractions: x^3/3 -> \frac{x^3}{3}
-    processedText = processedText.replace(/([a-zA-Z]\^?\{?\d*\}?)\s*\/\s*(\d+)/g, '\\frac{$1}{$2}');
+    processedText = processedText.replace(
+      /([a-zA-Z]\^?\{?\d*\}?)\s*\/\s*(\d+)/g,
+      (_, numerator, denominator) => String.raw`\frac{${numerator}}{${denominator}}`
+    );
 
     // Handle powers: x^2 -> x^{2}
     processedText = processedText.replace(/([a-zA-Z])\^(\d+)/g, '$1^{$2}');
 
     // Handle square roots: sqrt(x) -> \sqrt{x}
-    processedText = processedText.replace(/\\sqrt\{([^}]+)\}/g, '$\\sqrt{$1}$');
+    processedText = processedText.replace(
+      /\\sqrt\{([^}]+)\}/g,
+      (_, value) => String.raw`$\sqrt{${value}}$`
+    );
 
     // Handle equations with equals (be more selective)
     processedText = processedText.replace(
@@ -59,6 +131,10 @@
         return `$${match.trim()}$`;
       }
     );
+
+    for (const [placeholder, latexLine] of integralPlaceholders.entries()) {
+      processedText = processedText.split(placeholder).join(latexLine);
+    }
 
     const parts = [];
     let currentPos = 0;

--- a/tests/unit/chat/MathMessage.test.js
+++ b/tests/unit/chat/MathMessage.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import MathMessage from '../../../src/lib/modules/chat/components/MathMessage.svelte';
+
+describe('MathMessage', () => {
+  it('normalizes unicode integrals into KaTeX-renderable math', () => {
+    const { container } = render(MathMessage, {
+      props: {
+        content: '∫ 2x dz = x^(2) + C'
+      }
+    });
+
+    const katexNode = container.querySelector('.katex');
+    expect(katexNode).toBeTruthy();
+    expect(container.querySelector('.katex-display')).toBeTruthy();
+
+    const annotation = katexNode.querySelector('annotation');
+    expect(annotation?.textContent).toContain('\\int 2x \\, dz = x^{2} + C');
+  });
+});


### PR DESCRIPTION
## Summary
- isolate Unicode integral lines with placeholders to normalize them into KaTeX-friendly LaTeX without disrupting other math processing
- add global handling for exponent patterns and differential spacing while preserving existing formatting logic
- tighten the MathMessage unit test to assert display-mode rendering and the normalized integral annotation

## Testing
- npm run test:run -- tests/unit/chat/MathMessage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e59c2264d48324816258962afcdea1